### PR TITLE
- Optimized Layout#refreshViewPositionsForTree() by removing any refe…

### DIFF
--- a/Blockly/Code/Layout/BlockGroupLayout.swift
+++ b/Blockly/Code/Layout/BlockGroupLayout.swift
@@ -104,6 +104,43 @@ public class BlockGroupLayout: Layout {
   }
 
   /**
+   Appends a given `BlockLayout` instance to `self.blockLayouts` and adopts it as a child.
+
+   If `blockLayout` had a previous `BlockGroupLayout` parent, it is removed as a child from that
+   parent. Additionally, any children that followed this `blockLayout` in its old parent are also
+   removed and appended to `self.blockLayouts`.
+
+   - Parameter blockLayout: The `BlockLayout` to adopt
+   - Parameter updateLayouts: If true, all parent layouts of this layout and of `blockLayout`'s
+   previous parent will be updated.
+   */
+  public func claimBlockLayoutAndFollowers(blockLayout: BlockLayout, updateLayouts: Bool = true) {
+    let oldParentLayout = blockLayout.parentBlockGroupLayout
+
+    var transferredLayouts = [BlockLayout]()
+    if let oldParentLayout = oldParentLayout,
+      let index = oldParentLayout.blockLayouts.indexOf(blockLayout)
+    {
+      while (index < oldParentLayout.blockLayouts.count) {
+        // Just remove block layout from `oldParentLayout.blockLayouts`
+        // We don't want to remove it via removeChildLayout(...) or else this will fire an event.
+        let transferLayout = oldParentLayout.blockLayouts.removeAtIndex(index)
+        transferredLayouts.append(transferLayout)
+      }
+    } else {
+      transferredLayouts.append(blockLayout)
+    }
+
+    // Transfer the layouts over to `newBlockGroupLayout`
+    appendBlockLayouts(transferredLayouts, updateLayout: false)
+
+    if updateLayouts {
+      updateLayoutUpTree()
+      oldParentLayout?.updateLayoutUpTree()
+    }
+  }
+
+  /**
   Removes a given block layout and all subsequent layouts from `blockLayouts`, and returns them in
   an array.
 

--- a/Blockly/Code/Layout/Layout.swift
+++ b/Blockly/Code/Layout/Layout.swift
@@ -118,9 +118,10 @@ public class Layout: NSObject {
   /// `contentSize`.
   internal private(set) final var totalSize: WorkspaceSize = WorkspaceSizeZero
 
-  /// The absolute position of this layout, relative to the root node, in the View coordinate
-  /// system.
-  private final var viewAbsolutePosition = CGPointZero
+  /// An offset that should be applied to the positions of `childLayouts`, specified in the
+  /// Workspace coordinate system.
+  internal final var childContentOffset: WorkspacePoint = WorkspacePointZero
+
   /**
   UIView frame for this layout relative to its parent *view* node's layout. For example, the parent
   view node layout for a Field is a Block, while the parent view node for a Block is a Workspace.
@@ -166,55 +167,6 @@ public class Layout: NSObject {
   }
 
   // MARK: - Public
-
-  /**
-   For a given `Layout`, adds it to `self.childLayouts` and sets its `parentLayout` property to
-   this instance.
-
-   If the given `Layout` had an existing parent, this method automatically removes it from that
-   parent's `childLayouts`. This ensures that child `Layout` objects do not belong to two different
-   `Layout` parents.
-
-   - Parameter layout: The child `Layout` to adopt
-   */
-  public func adoptChildLayout(layout: Layout) {
-    if layout.parentLayout == self {
-      return
-    }
-
-    let oldParentLayout = layout.parentLayout
-
-    // Remove the child layout from its old parent (if necessary)
-    oldParentLayout?.childLayouts.remove(layout)
-
-    // Add this child layout and set its parent
-    childLayouts.insert(layout)
-    layout.parentLayout = self
-
-    // Fire hierachy listeners
-    hierarchyListeners.forEach {
-      $0.layout(self, didAdoptChildLayout: layout, fromOldParentLayout: oldParentLayout)
-    }
-  }
-
-  /**
-   For a given `Layout`, removes it from `self.childLayouts` and sets its `parentLayout` property to
-   `nil`.
-
-   - Parameter layout: The child `Layout` to remove
-   */
-  public func removeChildLayout(layout: Layout) {
-    if !childLayouts.contains(layout) {
-      return
-    }
-
-    // Remove this child layout
-    childLayouts.remove(layout)
-    layout.parentLayout = nil
-
-    // Fire hierachy listeners
-    hierarchyListeners.forEach { $0.layout(self, didRemoveChildLayout: layout) }
-  }
 
   /**
   For every `Layout` in its tree hierarchy (including itself), this method recalculates its
@@ -287,33 +239,73 @@ public class Layout: NSObject {
   // MARK: - Internal
 
   /**
-  For every `Layout` in its tree hierarchy (including itself), updates the `absolutePosition`,
-  `viewFrameOrigin`, and `viewFrame` based on the current state of this object.
+   For a given `Layout`, adds it to `self.childLayouts` and sets its `parentLayout` property to
+   this instance.
+
+   If the given `Layout` had an existing parent, this method automatically removes it from that
+   parent's `childLayouts`. This ensures that child `Layout` objects do not belong to two different
+   `Layout` parents. The `relativePosition` of `layout` is also recalculated relative to its new
+   parent (based on where it was before) and `layout.refreshViewPositionsForTree()` is executed.
+
+   - Parameter layout: The child `Layout` to adopt
+   */
+  internal func adoptChildLayout(layout: Layout) {
+    if layout.parentLayout == self {
+      return
+    }
+
+    let oldParentLayout = layout.parentLayout
+
+    // Remove the child layout from its old parent (if necessary)
+    if let oldParentLayout = oldParentLayout {
+      oldParentLayout.childLayouts.remove(layout)
+      // Update its new relative position to where it is in its new layout tree
+      layout.relativePosition = layout.absolutePosition - absolutePosition
+      // With the new relative position, refresh the view positions for this part of the tree
+      layout.refreshViewPositionsForTree()
+    }
+
+    // Add this child layout and set its parent
+    childLayouts.insert(layout)
+    layout.parentLayout = self
+
+    // Fire hierachy listeners
+    hierarchyListeners.forEach {
+      $0.layout(self, didAdoptChildLayout: layout, fromOldParentLayout: oldParentLayout)
+    }
+  }
+
+  /**
+   For a given `Layout`, removes it from `self.childLayouts` and sets its `parentLayout` property to
+   `nil`.
+
+   - Parameter layout: The child `Layout` to remove
+   */
+  internal func removeChildLayout(layout: Layout) {
+    if !childLayouts.contains(layout) {
+      return
+    }
+
+    // Remove this child layout
+    childLayouts.remove(layout)
+    layout.parentLayout = nil
+
+    // Fire hierachy listeners
+    hierarchyListeners.forEach { $0.layout(self, didRemoveChildLayout: layout) }
+  }
+
+  /**
+  For every `Layout` in its tree hierarchy (including itself), updates `self.absolutePosition`
+  and `self.viewFrame` based on the current state of this object.
 
   - Parameter includeFields: If true, recursively update view frames for field layouts. If false,
   skip them.
   */
   internal final func refreshViewPositionsForTree(includeFields includeFields: Bool = true) {
-    var parentViewAbsolutePosition = (parentLayout?.viewAbsolutePosition ?? CGPointZero)
-
-    if let workspaceLayout = self as? WorkspaceLayout where parentLayout == nil {
-      // This is a special case for when all view positions are being refreshed at the root
-      // workspace.
-      // Because UIScrollView is limited to scrolling positive coordiates, we must offset all
-      // block view origin coordinates so they are >= (0, 0). To do this, we simply set the
-      // `parentViewAbsolutePosition` for all blocks to be offset by the
-      // `workspaceLayout.contentOrigin`
-      let viewContentOrigin = self.engine.viewPointFromWorkspacePoint(workspaceLayout.contentOrigin)
-
-      // Note that in RTL, we must flip the X offset
-      parentViewAbsolutePosition.x = self.engine.rtl ? viewContentOrigin.x : -viewContentOrigin.x
-      parentViewAbsolutePosition.y = -viewContentOrigin.y
-    }
-
     refreshViewPositionsForTree(
       parentAbsolutePosition: (parentLayout?.absolutePosition ?? WorkspacePointZero),
-      parentViewAbsolutePosition: parentViewAbsolutePosition,
       parentContentSize: (parentLayout?.contentSize ?? self.contentSize),
+      contentOffset: (parentLayout?.childContentOffset ?? WorkspacePointZero),
       rtl: self.engine.rtl,
       includeFields: includeFields)
   }
@@ -340,15 +332,15 @@ public class Layout: NSObject {
   // MARK: - Private
 
   /**
-  For every `Layout` in its tree hierarchy (including itself), updates the `absolutePosition`,
-  `viewFrameOrigin`, and `viewFrame` based on the current state of this object.
+  For every `Layout` in its tree hierarchy (including itself), updates `self.absolutePosition`
+  and `self.viewFrame` based on the current state of this object.
 
   - Parameter parentAbsolutePosition: The absolute position of its parent layout (specified as a
   Workspace coordinate system point)
-  - Parameter parentViewAbsolutePosition: The absolute position of its parent's view (specified as a
-  UIView coordinate system point)
-  - Parameter parentContentSize: The content size of its parent layout (specified as a Workspaced
+  - Parameter parentContentSize: The content size of its parent layout (specified as a Workspace
   coordinate system size)
+  - Parameter contentOffset: An offset that should be applied to this view frame (specified as a
+  Workspace coordinate system point)
   - Parameter rtl: Flag for if the layout should be positioned in RTL mode.
   - Parameter includeFields: If true, recursively update view positions for field layouts. If false,
   skip them.
@@ -357,8 +349,8 @@ public class Layout: NSObject {
   */
   private final func refreshViewPositionsForTree(
     parentAbsolutePosition parentAbsolutePosition: WorkspacePoint,
-    parentViewAbsolutePosition: CGPoint,
     parentContentSize: WorkspaceSize,
+    contentOffset: WorkspacePoint,
     rtl: Bool, includeFields: Bool)
   {
     // TODO:(#29) Optimize this method so it only recalculates view positions for layouts that
@@ -369,32 +361,22 @@ public class Layout: NSObject {
       parentAbsolutePosition.x + relativePosition.x + edgeInsets.left,
       parentAbsolutePosition.y + relativePosition.y + edgeInsets.top)
 
-    // Update the layout's absolute position in the view coordinate system
-    var viewRelativePosition = CGPointZero
-    if rtl {
-      // In RTL, the x position is calculated relative to the top-right corner of its parent
-      viewRelativePosition.x = self.engine.viewUnitFromWorkspaceUnit(
-        parentContentSize.width - (relativePosition.x + edgeInsets.left + contentSize.width))
-    } else {
-      viewRelativePosition.x =
-        self.engine.viewUnitFromWorkspaceUnit(relativePosition.x + edgeInsets.left)
-    }
-    viewRelativePosition.y = self.engine.viewUnitFromWorkspaceUnit(
-      relativePosition.y + edgeInsets.top)
-    self.viewAbsolutePosition = parentViewAbsolutePosition + viewRelativePosition
-
-    // Update the view frame
+    // Update the view frame, if needed
     if (includeFields || !(self is FieldLayout))
     {
-      let viewFrameOrigin: CGPoint
-      if self.parentLayout is WorkspaceLayout {
-        // For top-level layouts, we want to use the absolute position.
-        // TODO:(#123) As an optimization, rewrite this method/functionality so self.parentLayout
-        // isn't called directly
-        viewFrameOrigin = viewAbsolutePosition
+      // Calculate the view frame's position
+      var viewFrameOrigin = CGPointZero
+      if rtl {
+        // In RTL, the x position is calculated relative to the top-right corner of its parent
+        viewFrameOrigin.x = self.engine.viewUnitFromWorkspaceUnit(
+          parentContentSize.width -
+          (relativePosition.x + edgeInsets.left + contentSize.width + contentOffset.x))
       } else {
-        viewFrameOrigin = viewRelativePosition
+        viewFrameOrigin.x = self.engine.viewUnitFromWorkspaceUnit(
+          relativePosition.x + edgeInsets.left + contentOffset.x)
       }
+      viewFrameOrigin.y = self.engine.viewUnitFromWorkspaceUnit(
+        relativePosition.y + edgeInsets.top + contentOffset.y)
 
       let viewSize = self.engine.viewSizeFromWorkspaceSize(self.contentSize)
       self.viewFrame =
@@ -406,8 +388,8 @@ public class Layout: NSObject {
       if includeFields || !(layout is FieldLayout) {
         layout.refreshViewPositionsForTree(
           parentAbsolutePosition: self.absolutePosition,
-          parentViewAbsolutePosition: self.viewAbsolutePosition,
           parentContentSize: self.contentSize,
+          contentOffset: self.childContentOffset,
           rtl: rtl,
           includeFields: includeFields)
       }

--- a/Blockly/Code/Layout/WorkspaceLayout.swift
+++ b/Blockly/Code/Layout/WorkspaceLayout.swift
@@ -108,6 +108,10 @@ public class WorkspaceLayout: Layout {
       bottomRightMostPoint.x - topLeftMostPoint.x,
       bottomRightMostPoint.y - topLeftMostPoint.y)
 
+
+    // Set the content offset so children are automatically placed relative to (0, 0)
+    self.childContentOffset = WorkspacePointZero - topLeftMostPoint
+
     // Update the canvas size
     scheduleChangeEventWithFlags(WorkspaceLayout.Flag_UpdateCanvasSize)
   }
@@ -459,40 +463,24 @@ extension WorkspaceLayout: ConnectionTargetDelegate {
       throw BlocklyError(.IllegalState, "Can't connect blocks from different workspaces")
     }
 
-    // TODO:(#119) Update this code to perform a proper move, instead of a remove/add. The reason is
-    // that a remove/add will force a corresponding remove/add on the view hierarchy, which isn't
-    // efficient that forces a view hierarchy recreation.
-
-    // Disconnect this block's layout and all subsequent block layouts from its block group layout,
-    // so they can be reattached to another block group layout
-    let layoutsToReattach: [BlockLayout]
-    if let oldParentLayout = sourceBlockLayout.parentBlockGroupLayout {
-      layoutsToReattach =
-        oldParentLayout.removeAllStartingFromBlockLayout(sourceBlockLayout, updateLayout: true)
-
-      if oldParentLayout.blockLayouts.count == 0 &&
-        oldParentLayout.parentLayout == workspace.layout {
-          // Remove this block's old parent group layout from the workspace level
-          removeBlockGroupLayout(oldParentLayout, updateLayout: true)
-      }
-    } else {
-      layoutsToReattach = [sourceBlockLayout]
-    }
+    // Keep a reference to the old parent block group layout, in case we need to clean it up later
+    // (if it becomes empty).
+    let oldParentLayout = sourceBlockLayout.parentBlockGroupLayout
 
     if let targetConnection = connection.targetConnection {
       // `targetConnection` is connected to something now.
       // Remove its shadow block layout tree (if it exists).
       try removeShadowBlockLayoutTree(forShadowBlock: targetConnection.shadowBlock)
 
-      // Reattach the layouts to the proper block group layout
+      // Move `sourceBlockLayout` and its followers to a new block group layout
       if let targetInputLayout = targetConnection.sourceInput?.layout {
-        // Reattach block layouts to target input's block group layout
+        // Move them to target input's block group layout
         targetInputLayout.blockGroupLayout
-          .appendBlockLayouts(layoutsToReattach, updateLayout: true)
+          .claimBlockLayoutAndFollowers(sourceBlockLayout, updateLayouts: true)
       } else if let targetBlockLayout = targetConnection.sourceBlock.layout {
-        // Reattach block layouts to the target block's group layout
+        // Move them to the target block's group layout
         targetBlockLayout.parentBlockGroupLayout?
-          .appendBlockLayouts(layoutsToReattach, updateLayout: true)
+          .claimBlockLayoutAndFollowers(sourceBlockLayout, updateLayouts: true)
       }
     } else {
       // The connection is no longer connected to anything.
@@ -508,12 +496,22 @@ extension WorkspaceLayout: ConnectionTargetDelegate {
       appendBlockGroupLayout(blockGroupLayout, updateLayout: false)
       bringBlockGroupLayoutToFront(blockGroupLayout)
 
-      // Reattach block layouts to a new block group layout
-      blockGroupLayout.appendBlockLayouts(layoutsToReattach, updateLayout: true)
+      // Move `sourceBlockLayout` and its followers to the new block group layout
+      blockGroupLayout.claimBlockLayoutAndFollowers(sourceBlockLayout, updateLayouts: true)
     }
 
     // Re-create the shadow block layout tree for the previous connection target (if it has one).
     try addShadowBlockLayoutTree(forConnection: oldTarget)
+
+    // If the previous block group layout parent of `sourceBlockLayout` is now empty and is at the
+    // the top-level of the workspace, remove it
+    if let emptyBlockGroupLayout = oldParentLayout
+      where emptyBlockGroupLayout.blockLayouts.count == 0 &&
+        emptyBlockGroupLayout.parentLayout == workspace.layout
+    {
+      // Remove this block's old parent group layout from the workspace level
+      removeBlockGroupLayout(emptyBlockGroupLayout, updateLayout: true)
+    }
 
     updateCanvasSize()
   }


### PR DESCRIPTION
…rence to self.parentLayout
- Added method in BlockGroupLayout to kidnap BlockLayout and followers from its existing parent

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/127)

<!-- Reviewable:end -->
