### PR TITLE
- Fixed performance of adding/removing/copying blocks in Workspace by…

### DIFF
--- a/Blockly/Code/Model/WorkspaceFlow.swift
+++ b/Blockly/Code/Model/WorkspaceFlow.swift
@@ -42,13 +42,17 @@ public class WorkspaceFlow: Workspace {
 
   public override func addBlockTree(rootBlock: Block) throws {
     try super.addBlockTree(rootBlock)
+
     items.append(Item(rootBlock: rootBlock))
+    layout?.updateLayoutUpTree()
   }
 
   public override func removeBlockTree(rootBlock: Block) throws {
     try super.removeBlockTree(rootBlock)
+
     // Remove item for this block (by only keeping blocks that don't match this rootBlock)
     items = items.filter({ $0.rootBlock != rootBlock })
+    layout?.updateLayoutUpTree()
   }
 
   // MARK: - Public

--- a/Blockly/Tests/Code/Layout/LayoutBuilderTest.swift
+++ b/Blockly/Tests/Code/Layout/LayoutBuilderTest.swift
@@ -358,8 +358,8 @@ class LayoutBuilderTest: XCTestCase {
         XCTAssertEqual(input.fields[i], fieldLayout.field)
 
         // Check that the field layout's parent is set to this input layout
-        if let parentInputLayout = fieldLayout.parentInputLayout {
-          XCTAssertEqual(inputLayout, parentInputLayout)
+        if let parentLayout = fieldLayout.parentLayout {
+          XCTAssertEqual(inputLayout, parentLayout)
         } else {
           XCTFail("Parent layout has not been set for field layout: \(fieldLayout)")
         }


### PR DESCRIPTION
… rearranging how delegate events were being fired (they were being overfired in instances like on block copy).
- Fixed WorkspaceFlow to update the layout on block add or remove

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/148)

<!-- Reviewable:end -->
