### PR TITLE
Adding reset function to BlocklyPanGestureRecognizer.

### DIFF
--- a/Blockly/Code/UI/BlocklyPanGestureRecognizer.swift
+++ b/Blockly/Code/UI/BlocklyPanGestureRecognizer.swift
@@ -253,12 +253,19 @@ public class BlocklyPanGestureRecognizer: UIGestureRecognizer {
   }
 
   /**
+   Called when the gesture recognizer terminates (ended, cancelled, or failed.) Cleans up internal
+   references.
+   */
+  public override func reset() {
+    _touches.removeAll()
+    _blocks.removeAll()
+  }
+
+  /**
    Manually cancels the touches of the gesture recognizer.
    */
   public func cancelAllTouches() {
-    _touches.removeAll()
-    _blocks.removeAll()
-
+    reset()
     state = .Cancelled
   }
 


### PR DESCRIPTION
This should fix UISwitches (And other continuous gestures attached to children of blocks) getting stuck in a state where they're un-endable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/182)

<!-- Reviewable:end -->
