### PR TITLE
Fixing the ZIndexedView hittest so it correctly falls through if a to…

### DIFF
--- a/Blockly/Code/UI/Views/ZIndexedGroupView.swift
+++ b/Blockly/Code/UI/Views/ZIndexedGroupView.swift
@@ -54,8 +54,10 @@ public final class ZIndexedGroupView: UIView {
       let pointForTargetView = target.convert(point, from: self)
 
       // If the touch is inside any child of this view, return the hit test for it.
-      if (target.bounds.contains(pointForTargetView)) {
-        return target.hitTest(pointForTargetView, with: event)
+      if target.bounds.contains(pointForTargetView),
+        let hitView = target.hitTest(pointForTargetView, with: event)
+      {
+        return hitView
       }
     }
 

--- a/Samples/BlocklySample/Code/SimpleWorkbenchViewController.swift
+++ b/Samples/BlocklySample/Code/SimpleWorkbenchViewController.swift
@@ -70,8 +70,8 @@ class SimpleWorkbenchViewController: WorkbenchViewController {
       let workspace = Workspace()
 
       // Add some blocks to the workspace
-      // try addChainedBlocksToWorkspace(workspace)
-      // try addSpaghettiBlocksToWorkspace(workspace)
+      // try addChainedBlocks(toWorkspace: workspace)
+      // try addSpaghettiBlocks(toWorkspace: workspace)
 
       try loadWorkspace(workspace)
     } catch let error as NSError {


### PR DESCRIPTION
…uch is inside its bounds but not its bezier path.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/197)

<!-- Reviewable:end -->
