### PR TITLE
- Fixed toolbox XML parsing so it accepts <xml> as a root node and so…

### DIFF
--- a/Samples/BlocklySample/Resources/Turtle/level_1/toolbox.xml
+++ b/Samples/BlocklySample/Resources/Turtle/level_1/toolbox.xml
@@ -13,7 +13,7 @@
   ~  limitations under the License.
   -->
 
-<toolbox>
+<xml>
   <category name="Turtle" colour="160">
     <block type="turtle_move">
       <value name="VALUE">
@@ -63,4 +63,4 @@
   <category name="Math" colour="230">
     <block type="math_number" />
   </category>
-</toolbox>
+</xml>

--- a/Source/Model/XML/Toolbox+XML.swift
+++ b/Source/Model/XML/Toolbox+XML.swift
@@ -49,11 +49,14 @@ extension Toolbox {
    malformed data, or contradictory data).
    */
   public class func makeToolbox(xml: AEXMLElement, factory: BlockFactory) throws -> Toolbox {
-    let toolboxNode = xml["toolbox"]
-
+    // Allow both "xml" (preferred) or "toolbox" as the root node
+    var toolboxNode = xml["xml"]
+    if toolboxNode.error != nil {
+      toolboxNode = xml["toolbox"]
+    }
     if let error = toolboxNode.error {
-      // if let error = toolboxNode.error {
-      throw BlocklyError(.xmlParsing, "An AEXMLError occurred parsing the <toolbox> node: \(error)")
+      throw BlocklyError(.xmlParsing,
+        "An AEXMLError occurred parsing the root node. Expected \"<xml>\": \(error)")
     }
 
     let toolbox = Toolbox()
@@ -68,6 +71,8 @@ extension Toolbox {
         if let colorHue = NumberFormatter().number(from: colorString) {
           let hue = (min(max(CGFloat(colorHue), 0), 360)) / 360
           color = ColorHelper.makeColor(hue: hue)
+        } else if let aColor = ColorHelper.makeColor(rgb: colorString) {
+          color = aColor
         } else {
           bky_print("Invalid toolbox category color: \"\(colorString)\"")
         }

--- a/Tests/Source/Model/XML/ToolboxXMLTest.swift
+++ b/Tests/Source/Model/XML/ToolboxXMLTest.swift
@@ -22,24 +22,50 @@ class ToolboxXMLTest: XCTestCase {
   var factory: BlockFactory!
 
   override func setUp() {
-    factory = try! BlockFactory(jsonPath: "all_test_blocks.json",
-      bundle: Bundle(for: type(of: self)))
+    factory = BKYAssertDoesNotThrow {
+      try BlockFactory(jsonPath: "all_test_blocks.json", bundle: Bundle(for: type(of: self)))
+    }
 
     super.setUp()
   }
 
   // MARK: - XML Parsing Tests
 
-  func testParseXML_EmptyToolbox() {
+  func testParseXML_EmptyToolboxWithXMLRoot() {
+    let xmlString = "<xml></xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
+
+    XCTAssertEqual(0, toolbox.categories.count)
+  }
+
+  func testParseXML_EmptyToolboxWithToolboxRoot() {
     let xmlString = "<toolbox></toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(0, toolbox.categories.count)
   }
 
   func testParseXML_EmptyCategory() {
-    let xmlString = "<toolbox><category name='abc' colour='180'></category></toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    let xmlString = "<xml><category name='abc' colour='180'></category></xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(1, toolbox.categories.count)
     XCTAssertEqual("abc", toolbox.categories[0].name)
@@ -47,13 +73,38 @@ class ToolboxXMLTest: XCTestCase {
       accuracy: TestConstants.ACCURACY_CGF)
   }
 
+  func testParseXML_EmptyCategoryWithRGBColor() {
+    let xmlString = "<xml><category name='abc' colour='#ff0000'></category></xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+        try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+      }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
+
+    XCTAssertEqual(1, toolbox.categories.count)
+    XCTAssertEqual("abc", toolbox.categories[0].name)
+    let rgba = toolbox.categories[0].color.bky_rgba()
+    XCTAssertEqualWithAccuracy(1.0, rgba.red, accuracy: TestConstants.ACCURACY_CGF)
+    XCTAssertEqualWithAccuracy(0.0, rgba.green, accuracy: TestConstants.ACCURACY_CGF)
+    XCTAssertEqualWithAccuracy(0.0, rgba.blue, accuracy: TestConstants.ACCURACY_CGF)
+    XCTAssertEqualWithAccuracy(1.0, rgba.alpha, accuracy: TestConstants.ACCURACY_CGF)
+  }
+
   func testParseXML_TwoCategory() {
     let xmlString =
-      "<toolbox>" +
+      "<xml>" +
         "<category name='cat1'></category>" +
         "<category name='cat2'></category>" +
-      "</toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+      "</xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(2, toolbox.categories.count)
     XCTAssertEqual("cat1", toolbox.categories[0].name)
@@ -62,10 +113,16 @@ class ToolboxXMLTest: XCTestCase {
 
   func testParseXML_SimpleBlock() {
     let xmlString =
-    "<toolbox>" +
+    "<xml>" +
       "<category name='cat1'><block type='multiple_input_output'></block></category>" +
-    "</toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    "</xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(1, toolbox.categories.count)
     XCTAssertEqual(1, toolbox.categories[0].items.count)
@@ -74,15 +131,21 @@ class ToolboxXMLTest: XCTestCase {
 
   func testParseXML_TwoBlocksWithGaps() {
     let xmlString =
-    "<toolbox>" +
+    "<xml>" +
       "<category name='cat1'>" +
         "<block type='block_output'></block>" +
         "<sep gap='10' />" +
         "<block type='block_statement'></block>" +
         "<sep></sep>" +
       "</category>" +
-    "</toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    "</xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(1, toolbox.categories.count)
 
@@ -96,7 +159,7 @@ class ToolboxXMLTest: XCTestCase {
 
   func testParseXML_NestedBlocks() {
     let xmlString =
-    "<toolbox>" +
+    "<xml>" +
       "<category name='cat1'>" +
         "<block type='controls_repeat_ext'>" +
           "<value name='TIMES'>" +
@@ -104,8 +167,14 @@ class ToolboxXMLTest: XCTestCase {
           "</value>" +
         "</block>" +
       "</category>" +
-    "</toolbox>"
-    let toolbox = try! Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    "</xml>"
+    guard let toolbox = BKYAssertDoesNotThrow({
+      try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
+    }) else
+    {
+      XCTFail("Could not create toolbox")
+      return
+    }
 
     XCTAssertEqual(1, toolbox.categories.count)
     XCTAssertEqual(2, toolbox.categories[0].allBlocks.count)
@@ -130,7 +199,7 @@ class ToolboxXMLTest: XCTestCase {
 
   func testParseXML_UnknownBlock() {
     do {
-      let xmlString = "<toolbox><category><block id='unknownblock'></block></category></toolbox>"
+      let xmlString = "<xml><category><block id='unknownblock'></block></category></xml>"
       _ = try Toolbox.makeToolbox(xmlString: xmlString, factory: factory)
       XCTFail("Toolbox was parsed successfully from bad XML: '\(xmlString)'")
     } catch let error as BlocklyError {


### PR DESCRIPTION
… it parses RGB colour values

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/205)

<!-- Reviewable:end -->
