### PR TITLE
- Fixed block XML parsing to spit out warnings for missing field info.

### DIFF
--- a/Source/Common/CodeGeneratorService.swift
+++ b/Source/Common/CodeGeneratorService.swift
@@ -206,7 +206,7 @@ extension CodeGeneratorService {
       jsonBlockDefinitions: [CodeGenerator.BundledFile],
       completion: CompletionClosure? = nil, error: ErrorClosure? = nil) throws
     {
-      self.init(workspaceXML: try workspace.toXML().xml,
+      self.init(workspaceXML: try workspace.toXML(),
         jsGeneratorObject: jsGeneratorObject, jsBlockGenerators: jsBlockGenerators,
         jsonBlockDefinitions: jsonBlockDefinitions, completion: completion, error: error)
     }

--- a/Source/Model/XML/Field+XML.swift
+++ b/Source/Model/XML/Field+XML.swift
@@ -19,7 +19,7 @@ import AEXML
 // MARK: - XML Serialization
 
 extension Field {
-  // MARK: - Public
+  // MARK: - Internal
 
   /**
    Creates an XML element for this field.
@@ -29,7 +29,7 @@ extension Field {
    - Throws:
    `BlocklyError`: Thrown if there was an error serializing this field.
    */
-  public func toXML() throws -> AEXMLElement? {
+  internal func toXMLElement() throws -> AEXMLElement? {
     if let serializedText = try self.serializedText() {
       return AEXMLElement(name: XMLConstants.TAG_FIELD,
                           value: serializedText, attributes: [XMLConstants.ATTRIBUTE_NAME: name])

--- a/Source/Model/XML/Input+XML.swift
+++ b/Source/Model/XML/Input+XML.swift
@@ -19,7 +19,7 @@ import AEXML
 // MARK: - XML Serialization
 
 extension Input {
-  // MARK: - Public
+  // MARK: - Internal
 
   /**
    Creates XML elements for this input and all of its descendants.
@@ -28,20 +28,20 @@ extension Input {
    - Throws:
    `BlocklyError`: Thrown if there was an error serializing this input or any of its descendants.
    */
-  public func toXML() throws -> [AEXMLElement] {
+  internal func toXMLElement() throws -> [AEXMLElement] {
     var xmlElements: [AEXMLElement]
     switch type {
     case InputType.dummy:
       xmlElements = []
     case InputType.value:
-      xmlElements = try toXML(withName: XMLConstants.TAG_INPUT_VALUE)
+      xmlElements = try toXMLElement(withName: XMLConstants.TAG_INPUT_VALUE)
     case InputType.statement:
-      xmlElements = try toXML(withName: XMLConstants.TAG_INPUT_STATEMENT)
+      xmlElements = try toXMLElement(withName: XMLConstants.TAG_INPUT_STATEMENT)
     }
 
     // Create xml elements for each field
     for field in fields {
-      if let fieldXML = try field.toXML() {
+      if let fieldXML = try field.toXMLElement() {
         xmlElements.append(fieldXML)
       }
     }
@@ -51,7 +51,7 @@ extension Input {
 
   // MARK: - Private
 
-  fileprivate func toXML(withName elementName: String) throws -> [AEXMLElement] {
+  fileprivate func toXMLElement(withName elementName: String) throws -> [AEXMLElement] {
     if connectedBlock == nil && connectedShadowBlock == nil {
       // No block connected, don't include any xml for this input
       return []
@@ -63,10 +63,10 @@ extension Input {
     let xml = AEXMLElement(
       name: elementName, value: nil, attributes: [XMLConstants.ATTRIBUTE_NAME: name])
     if let connectedBlock = connectedBlock {
-      xml.addChild(try connectedBlock.toXML())
+      xml.addChild(try connectedBlock.toXMLElement())
     }
     if let connectedShadowBlock = connectedShadowBlock {
-      xml.addChild(try connectedShadowBlock.toXML())
+      xml.addChild(try connectedShadowBlock.toXMLElement())
     }
     xmlElements.append(xml)
 

--- a/Source/Model/XML/Workspace+XML.swift
+++ b/Source/Model/XML/Workspace+XML.swift
@@ -60,19 +60,33 @@ extension Workspace {
   // MARK: - Public
 
   /**
-   Creates an XML document representing the current state of this workspace.
+   Returns an XML string representing the current state of this workspace.
+
+   - Returns: The XML string.
+   - Throws:
+   `BlocklyError`: Thrown if there was an error serializing any of the blocks in the workspace.
+   */
+  @objc(toXMLWithError:)
+  public func toXML() throws -> String {
+    return try toXMLDocument().xml
+  }
+
+  // MARK: - Internal
+
+  /**
+   Creates and returns an XML document representing the current state of this workspace.
 
    - Returns: An XML document.
    - Throws:
    `BlocklyError`: Thrown if there was an error serializing any of the blocks in the workspace.
    */
-  public func toXML() throws -> AEXMLDocument {
+  internal func toXMLDocument() throws -> AEXMLDocument {
     let xmlDoc = AEXMLDocument()
     let rootXML = xmlDoc.addChild(name: "xml", value: nil,
-      attributes: ["xmlns": "http://www.w3.org/1999/xhtml"])
+                                  attributes: ["xmlns": "http://www.w3.org/1999/xhtml"])
 
     for block in topLevelBlocks() {
-      rootXML.addChild(try block.toXML())
+      rootXML.addChild(try block.toXMLElement())
     }
 
     return xmlDoc

--- a/Tests/Source/Model/XML/BlockXMLTest.swift
+++ b/Tests/Source/Model/XML/BlockXMLTest.swift
@@ -297,7 +297,7 @@ class BlockXMLTest: XCTestCase {
 
     // This is the xml we expect from `block`:
     // <block type=\"empty_block\" id=\"364\" x=\"37\" y=\"13\" />
-    let xml = try! block?.toXML()
+    let xml = try! block?.toXMLElement()
     XCTAssertEqual("block", xml?.name)
     XCTAssertEqual(4, xml?.attributes.count)
     XCTAssertEqual("block_uuid", xml?.attributes["id"])
@@ -314,7 +314,7 @@ class BlockXMLTest: XCTestCase {
 
     // This is the xml we expect from `block`:
     // <block type=\"empty_block\" id=\"364\" x=\"0\" y=\"0\" />
-    let xml = try! block?.toXML()
+    let xml = try! block?.toXMLElement()
     XCTAssertEqual("block", xml?.name)
     XCTAssertEqual(4, xml?.attributes.count)
     XCTAssertEqual("uuid", xml?.attributes["id"])
@@ -352,7 +352,7 @@ class BlockXMLTest: XCTestCase {
     //   <field name="checkbox">true</field>
     // </block>
 
-    let xml = try! block.toXML()
+    let xml = try! block.toXMLElement()
 
     // Test: <block id="364" x="37" y="13" type="frankenblock">
     XCTAssertEqual("block", xml.name)
@@ -437,7 +437,7 @@ class BlockXMLTest: XCTestCase {
     //   <field name="colour">#ff0000</field>
     // </block>
 
-    let xml = try! block.toXML()
+    let xml = try! block.toXMLElement()
 
     // Test: <block type="frankenblock" id="1000" x="0" y="0">
     XCTAssertEqual("block", xml.name)
@@ -556,7 +556,7 @@ class BlockXMLTest: XCTestCase {
     //   </next>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not build XML")
       return
     }
@@ -601,7 +601,7 @@ class BlockXMLTest: XCTestCase {
     // This is the xml we expect from `block`:
     // <shadow type=\"empty_block\" id=\"abc\" x=\"350\" y=\"-10\" />
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }
@@ -641,7 +641,7 @@ class BlockXMLTest: XCTestCase {
     //   </value>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }
@@ -705,7 +705,7 @@ class BlockXMLTest: XCTestCase {
     //   </value>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }
@@ -776,7 +776,7 @@ class BlockXMLTest: XCTestCase {
     //   </statement>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not build XML")
       return
     }
@@ -843,7 +843,7 @@ class BlockXMLTest: XCTestCase {
     //   </statement>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not build XML")
       return
     }
@@ -912,7 +912,7 @@ class BlockXMLTest: XCTestCase {
     //   </next>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }
@@ -975,7 +975,7 @@ class BlockXMLTest: XCTestCase {
     //   </next>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }
@@ -1076,7 +1076,7 @@ class BlockXMLTest: XCTestCase {
     //   </next>
     // </block>
 
-    guard let xml = BKYAssertDoesNotThrow({ try block.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try block.toXMLElement() }) else {
       XCTFail("Could not serialize block into XML")
       return
     }

--- a/Tests/Source/Model/XML/FieldXMLTest.swift
+++ b/Tests/Source/Model/XML/FieldXMLTest.swift
@@ -23,7 +23,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldAngle() {
     let field = FieldAngle(name: "a_field", angle: 300)
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">300</field>
     XCTAssertNotNil(fieldXML)
@@ -36,7 +36,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldCheckbox() {
     let field = FieldCheckbox(name: "a_field", checked: false)
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">false</field>
     XCTAssertNotNil(fieldXML)
@@ -49,7 +49,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldColor() {
     let field = FieldColor(name: "a_field", color: UIColor.red)
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">#FF0000</field>
     XCTAssertNotNil(fieldXML)
@@ -62,7 +62,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldDate() {
     let field = FieldDate(name: "a_field", stringDate: "1970-01-01")
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">#FF0000</field>
     XCTAssertNotNil(fieldXML)
@@ -76,7 +76,7 @@ class FieldXMLTest: XCTestCase {
   func testSerializeXML_FieldDropdown() {
     let field = try! FieldDropdown(name: "a_field",
       displayNames: ["Test 1", "Test 2"], values: ["Value 1", "Value 2"], selectedIndex: 1)
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">Value 2</field>
     XCTAssertNotNil(fieldXML)
@@ -90,7 +90,7 @@ class FieldXMLTest: XCTestCase {
   func testSerializeXML_FieldImage() {
     let field =
       FieldImage(name: "a_field", imageLocation: "some_image.png", size: WorkspaceSize.zero, altText: "")
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: nil
     XCTAssertNil(fieldXML)
@@ -98,7 +98,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldInput() {
     let field = FieldInput(name: "a_field", text: "some input")
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">some input</field>
     XCTAssertNotNil(fieldXML)
@@ -111,7 +111,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldLabel() {
     let field = FieldLabel(name: "a_field", text: "some label")
-    let fieldXML = try! field.toXML()
+    let fieldXML = try! field.toXMLElement()
 
     // Expected: nil
     XCTAssertNil(fieldXML)
@@ -119,7 +119,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldNumber() {
     let field = FieldNumber(name: "a_field", value: -30.50)
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">-30.5</field>
     XCTAssertNotNil(fieldXML)
@@ -132,7 +132,7 @@ class FieldXMLTest: XCTestCase {
 
   func testSerializeXML_FieldVariable() {
     let field = FieldVariable(name: "a_field", variable: "variableName")
-    let fieldXML = BKYAssertDoesNotThrow { try field.toXML() }
+    let fieldXML = BKYAssertDoesNotThrow { try field.toXMLElement() }
 
     // Expected: <field name="a_field">variableName</field>
     XCTAssertNotNil(fieldXML)

--- a/Tests/Source/Model/XML/WorkspaceXMLTest.swift
+++ b/Tests/Source/Model/XML/WorkspaceXMLTest.swift
@@ -107,7 +107,7 @@ class WorkspaceXMLTest: XCTestCase {
 
   func testSerializeXML_EmptyWorkspace() {
     let workspace = Workspace()
-    let xml = try! workspace.toXML()
+    let xml = try! workspace.toXMLDocument()
 
     // Expected: <xml xmlns="http://www.w3.org/1999/xhtml" />
     XCTAssertEqual("xml", xml.root.name)
@@ -120,7 +120,7 @@ class WorkspaceXMLTest: XCTestCase {
     let workspace = Workspace()
     let block = try! Block.Builder(name: "test").makeBlock(uuid: "12345")
     try! workspace.addBlockTree(block)
-    let xml = try! workspace.toXML()
+    let xml = try! workspace.toXMLDocument()
 
     // Expected:
     // <xml xmlns="http://www.w3.org/1999/xhtml">
@@ -148,7 +148,7 @@ class WorkspaceXMLTest: XCTestCase {
     let block2 = try! Block.Builder(name: "test2").makeBlock(uuid: "200")
     try! workspace.addBlockTree(block1)
     try! workspace.addBlockTree(block2)
-    let xml = try! workspace.toXML()
+    let xml = try! workspace.toXMLDocument()
 
     // Expected:
     // <xml xmlns="http://www.w3.org/1999/xhtml">
@@ -179,7 +179,7 @@ class WorkspaceXMLTest: XCTestCase {
 
     let workspace = Workspace()
     BKYAssertDoesNotThrow { try workspace.addBlockTree(parent) }
-    guard let xml = BKYAssertDoesNotThrow({ try workspace.toXML() }) else {
+    guard let xml = BKYAssertDoesNotThrow({ try workspace.toXMLDocument() }) else {
       XCTFail("Could not build XML")
       return
     }


### PR DESCRIPTION
- Fixed ObjC compatibility for toXML() for Workspace and Block
- Changed methods returning AEXML objects to be internal instead of public

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/215)

<!-- Reviewable:end -->
