### PR TITLE
- Updated podspec resource path

### DIFF
--- a/Blockly.podspec
+++ b/Blockly.podspec
@@ -30,17 +30,23 @@ Pod::Spec.new do |s|
   s.source_files     = 'Source/**/*'
 
   # It appears resources inside xcassets can't be loaded from packaged resource bundles, so that
-  # is why we include Blockly.xcassets through '.resources', instead of '.resource_bundles'.
-  s.resources = ['Resources/Blockly.xcassets', 'Resources/code_generator']
+  # is why we use '.resources', instead of '.resource_bundles' (or else Blockly.xcassets wouldn't
+  # be included properly).
+  s.resources = 'Resources/**'
 
   s.frameworks        = 'WebKit'
   s.ios.dependency 'AEXML', '~> 4.0.1'
 
-  # Enable whole-module-optimization for all builds except for Debug builds
   s.pod_target_xcconfig = {
+      # Enable whole-module-optimization for all builds except for Debug builds
       'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule',
       'SWIFT_OPTIMIZATION_LEVEL[config=Debug]' => '-Onone',
+
+      # Let Xcode know Blockly uses Swift 3.0 syntax
       'SWIFT_VERSION' => '3.0',
+
+      # Swift standard libraries need to be included for Blockly to work!
+      'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'YES',
   }
 
 end

--- a/Blockly.xcodeproj/project.pbxproj
+++ b/Blockly.xcodeproj/project.pbxproj
@@ -1199,6 +1199,7 @@
 		FA548C1C1B630BAD008BC59C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -1226,6 +1227,7 @@
 		FA548C1D1B630BAD008BC59C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
- Updated Blockly project and podspec so the Blockly target always embeds Swift standard libraries

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/217)

<!-- Reviewable:end -->
