### PR TITLE
- Fixed retain cycle caused by ViewManager

### DIFF
--- a/Source/Common/CodeGeneratorServiceRequestBuilder.swift
+++ b/Source/Common/CodeGeneratorServiceRequestBuilder.swift
@@ -30,12 +30,6 @@ open class CodeGeneratorServiceRequestBuilder: NSObject {
   open private(set) var jsBlockGeneratorFiles = [BundledFile]()
   /// List of JSON files containing block definitions that should be used for each request
   open private(set) var jsonBlockDefinitionFiles = [BundledFile]()
-  /// Callback that is executed when code generation completes successfully. This is always
-  /// executed on the main thread.
-  open var onCompletion: CodeGeneratorServiceRequest.CompletionClosure?
-  /// Callback that is executed when code generation fails. This is always executed on the main
-  /// thread.
-  open var onError: CodeGeneratorServiceRequest.ErrorClosure?
 
   // MARK: - Initializers
 
@@ -114,7 +108,7 @@ open class CodeGeneratorServiceRequestBuilder: NSObject {
       workspaceXML: workspaceXML, jsGeneratorObject: jsGeneratorObject,
       jsBlockGeneratorFiles: jsBlockGeneratorFiles,
       jsonBlockDefinitionFiles: jsonBlockDefinitionFiles,
-      onCompletion: onCompletion, onError: onError)
+      onCompletion: nil, onError: nil)
   }
 
   /**

--- a/Source/Common/ObjectPool.swift
+++ b/Source/Common/ObjectPool.swift
@@ -21,11 +21,6 @@ import Foundation
 @objc(BKYRecyclable)
 public protocol Recyclable: class {
   /**
-   Instantiates a new instance of the recyclable class.
-   */
-  init()
-
-  /**
    Reset the object to a fresh state, releasing and recycling any resources associated with this
    object.
 
@@ -53,33 +48,19 @@ public final class ObjectPool: NSObject {
   /**
   If a recycled object is available for re-use, that object is returned.
 
-  If not, a new object of the given `Recyclable.Type` is instantiated.
+  If not, a new object of the given type is instantiated.
 
-  - parameter type: The type of `Recyclable` object to retrieve.
+
+  - parameter type: The `Type` of object to retrieve.
   - note: Objects obtained through this method should be recycled through `recycleObject(:)`.
-  - returns: An object of the given type.
+  - returns: An object of the given `type`.
   */
-  public func objectForType<T: Recyclable>(_ type: T.Type) -> T {
-    // Force cast Recyclable back into the concrete "T" type
-    return recyclableObjectForType(type) as! T
-  }
-
-  /**
-   If a recycled object is available for re-use, that object is returned.
-
-   If not, a new object of the given `Recyclable.Type` is instantiated.
-
-   - parameter type: The type of `Recyclable` object to retrieve.
-   - note: Objects obtained through this method should be recycled through `recycleObject(:)`.
-   - Warning: This method should only be called by Objective-C code. Swift code should use
-   `objectForType(type:)` instead.
-   - returns: An object of the given type.
-   */
-  public func recyclableObjectForType(_ type: Recyclable.Type) -> Recyclable {
+  public func object<T>(forType type: T.Type) -> T where T: NSObject {
     let className = String(describing: type) as NSString
 
-    if let list = _recycledObjects.object(forKey: className), list.count > 0 {
-      let recycledObject = list.lastObject as! Recyclable
+    if let list = _recycledObjects.object(forKey: className), list.count > 0,
+      let recycledObject = list.lastObject as? T
+    {
       list.removeLastObject()
       return recycledObject
     }

--- a/Source/UI/Views/ViewFactory.swift
+++ b/Source/UI/Views/ViewFactory.swift
@@ -28,7 +28,7 @@ open class ViewFactory: NSObject {
 
   /// Dictionary that maps `Layout` subclasses (using their class' `hash()` value) to their
   /// `LayoutView` type
-  private var _viewMapping = [Int: Recyclable.Type]()
+  private var _viewMapping = [Int: LayoutView.Type]()
 
   /**
    Initializes the view factory, and registers the default `Layout`/`View` relationships
@@ -67,11 +67,10 @@ open class ViewFactory: NSObject {
   open func makeView(layout: Layout) throws -> LayoutView {
     // Get a fresh view and populate it with the layout
     let layoutType = type(of: layout)
-    if let viewType = _viewMapping[layoutType.hash()],
-      let view = recyclableViewForType(viewType) as? LayoutView
-    {
-      view.layout = layout
-      return view
+    if let viewType = _viewMapping[layoutType.hash()] {
+      let layoutView = view(forType: viewType)
+      layoutView.layout = layout
+      return layoutView
     } else {
       throw BlocklyError(.viewNotFound, "Could not retrieve view for \(layoutType)")
     }
@@ -93,13 +92,13 @@ open class ViewFactory: NSObject {
    If a recycled view is available for re-use, that view is returned.
    If not, a new view of the given type is instantiated.
 
-   - parameter type: The type of `Recyclable` object to retrieve.
+   - parameter type: The type of `UIView` object to retrieve.
    - note: Views obtained through this method should be recycled through `recycleView(:)` or
    `recycleViewTree(:)`.
-   - returns: A view of the given type, if it is a `UIView`. Otherwise, nil is returned.
+   - returns: An object of the given `type`.
    */
-  open func recyclableViewForType(_ type: Recyclable.Type) -> UIView? {
-    return _objectPool.recyclableObjectForType(type) as? UIView
+  open func view<T>(forType type: T.Type) -> T where T: UIView {
+    return _objectPool.object(forType: type)
   }
 
   /**

--- a/Source/UI/Views/ViewManager.swift
+++ b/Source/UI/Views/ViewManager.swift
@@ -27,8 +27,8 @@ public final class ViewManager: NSObject {
 
   // MARK: - Properties
 
-  /// Dictionary mapping instances of `LayoutView` keyed by their `layout.uuid`
-  private var _views = [String: LayoutView]()
+  /// Dictionary that indexes weak `LayoutView` references based on their `layout.uuid`
+  private var _views: NSMapTable<NSString, LayoutView> = NSMapTable.strongToWeakObjects()
 
   // MARK: - Public
 
@@ -39,7 +39,7 @@ public final class ViewManager: NSObject {
    - parameter layout: The `Layout` associated with the view
    */
   public func cacheView(_ layoutView: LayoutView, forLayout layout: Layout) {
-    _views[layout.uuid] = layoutView
+    _views.setObject(layoutView, forKey: layout.uuid as NSString?)
   }
 
   /**
@@ -48,7 +48,7 @@ public final class ViewManager: NSObject {
    - parameter layout: The given layout
    */
   public func uncacheView(forLayout layout: Layout) {
-    _views[layout.uuid] = nil
+    _views.removeObject(forKey: layout.uuid as NSString?)
   }
 
   /**
@@ -59,7 +59,7 @@ public final class ViewManager: NSObject {
    - returns: A `BlockView` with the given layout assigned to it, or nil if no view could be found.
    */
   public func findBlockView(forLayout layout: BlockLayout) -> BlockView? {
-    return (_views[layout.uuid] as? BlockView) ?? nil
+    return (findView(forLayout: layout) as? BlockView) ?? nil
   }
 
   /**
@@ -70,7 +70,7 @@ public final class ViewManager: NSObject {
    - returns: A `FieldView` with the given layout assigned to it, or nil if no view could be found.
    */
   public func findFieldView(forLayout layout: FieldLayout) -> FieldView? {
-    return (_views[layout.uuid] as? FieldView) ?? nil
+    return (findView(forLayout: layout) as? FieldView) ?? nil
   }
 
   /**
@@ -80,7 +80,8 @@ public final class ViewManager: NSObject {
    - parameter layout: The `Layout` to look for
    - returns: A `LayoutView` with the given layout assigned to it, or nil if no view could be found.
    */
+  @inline(__always)
   public func findView(forLayout layout: Layout) -> LayoutView? {
-    return _views[layout.uuid]
+    return _views.object(forKey: layout.uuid as NSString?)
   }
 }

--- a/Tests/Source/Core/Common/ObjectPoolTest.swift
+++ b/Tests/Source/Core/Common/ObjectPoolTest.swift
@@ -30,12 +30,12 @@ class ObjectPoolTest: XCTestCase {
 
     // Check they were recycled
     for _ in 0 ..< cokeCans.count {
-      let recycledCan = pool.objectForType(CokeCan.self)
+      let recycledCan = pool.object(forType: CokeCan.self)
       XCTAssertTrue(recycledCan.recycled)
     }
 
     // Get a new one, which should not have been recycled
-    let freshOne = pool.objectForType(CokeCan.self)
+    let freshOne = pool.object(forType: CokeCan.self)
     XCTAssertFalse(freshOne.recycled)
   }
 
@@ -51,7 +51,7 @@ class ObjectPoolTest: XCTestCase {
       }
 
       for _ in 0 ..< count {
-        _ = pool.recyclableObjectForType(CokeCan.self)
+        _ = pool.object(forType: CokeCan.self)
       }
     }
   }


### PR DESCRIPTION
- Fixed memory leak caused by ObjectPool creating objects from a protocol instead of an object
- Fixed the code order of how view controllers are added to parent VCs
- Removed onCompletion/onError from CodeGeneratorServiceRequestBuilder since it made it prone for users to create retain cycles accidentally
- Fixed both turtle demos by breaking automatic retain cycle caused by WKUserContentController
- Added missing comments to obj-c turtle demo

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/241)

<!-- Reviewable:end -->
