### PR TITLE
- Added UI option for rendering a Start Hat.

### DIFF
--- a/Source/Layout/Default/DefaultBlockLayout+Background.swift
+++ b/Source/Layout/Default/DefaultBlockLayout+Background.swift
@@ -29,19 +29,26 @@ extension DefaultBlockLayout {
     /// Flag if the bottom-left corner should be rounded
     public fileprivate(set) var squareBottomLeftCorner: Bool = false
 
-    /// Flag if a female previous statement connector should be rendered at the top of the block
-    public fileprivate(set) var femalePreviousStatementConnector: Bool = false
+    /// Flag if a previous statement connector should be rendered at the top of the block
+    public fileprivate(set) var previousStatementConnector: Bool = false
 
-    /// Flag if a male next statement connector should be rendered at the bottom of the block
-    public fileprivate(set) var maleNextStatementConnector: Bool = false
+    /// Flag if a next statement connector should be rendered at the bottom of the block
+    public fileprivate(set) var nextStatementConnector: Bool = false
 
-    /// Flag if a male output connector should be rendered on the left side of the block
-    public fileprivate(set) var maleOutputConnector: Bool = false
+    /// Flag if a output connector should be rendered on the left side of the block
+    public fileprivate(set) var outputConnector: Bool = false
+
+    /// Flag if the block should render a hat
+    public fileprivate(set) var startHat: Bool = false
 
     /// The position of the block's leading X edge offset, specified as a Workspace coordinate
     /// system unit, relative to its entire bounding box.
     /// (e.g. In LTR, this is the X offset of the block's left edge.)
-    public var leadingEdgeXOffset: CGFloat = 0
+    public fileprivate(set) var leadingEdgeXOffset: CGFloat = 0
+
+    /// The position of the block's top Y edge offset, specified as a Workspace coordinate
+    /// system unit.
+    public fileprivate(set) var leadingEdgeYOffset: CGFloat = 0
 
     /// The rows for this block
     public fileprivate(set) var rows = [BackgroundRow]()
@@ -54,11 +61,15 @@ extension DefaultBlockLayout {
     - parameter layout: The block layout.
     */
     public func updateRenderProperties(fromBlockLayout layout: DefaultBlockLayout) {
-      self.maleOutputConnector = (layout.block.outputConnection != nil)
-      self.leadingEdgeXOffset = maleOutputConnector ?
+      self.outputConnector = (layout.block.outputConnection != nil)
+      self.previousStatementConnector = (layout.block.previousConnection != nil)
+      self.nextStatementConnector = (layout.block.nextConnection != nil)
+      self.startHat = !previousStatementConnector && !outputConnector &&
+        layout.config.bool(for: DefaultLayoutConfig.BlockStartHat)
+      self.leadingEdgeXOffset = outputConnector ?
         layout.config.workspaceUnit(for: DefaultLayoutConfig.PuzzleTabWidth) : 0
-      self.femalePreviousStatementConnector = (layout.block.previousConnection != nil)
-      self.maleNextStatementConnector = (layout.block.nextConnection != nil)
+      self.leadingEdgeYOffset = startHat ?
+        layout.config.workspaceSize(for: DefaultLayoutConfig.BlockStartHatSize).height : 0
 
       if layout.block.outputConnection != nil {
         self.squareTopLeftCorner = true
@@ -101,8 +112,8 @@ extension DefaultBlockLayout {
   public final class BackgroundRow: NSObject {
     // MARK: - Properties
 
-    /// Flag if a female output connector should be rendered on the right side of the row
-    public var femaleOutputConnector: Bool = false
+    /// Flag if a output connector should be rendered on the right side of the row
+    public var outputConnector: Bool = false
 
     /// Flag if this row represents a "C" shaped statement block.
     public var isStatement: Bool = false
@@ -169,7 +180,7 @@ extension DefaultBlockLayout {
         self.statementConnectorWidth = lastInputLayout.statementConnectorWidth
       } else if !lastInputLayout.input.sourceBlock.inputsInline {
         self.rightEdge = lastInputLayout.rightEdge
-        self.femaleOutputConnector = (lastInputLayout.input.connection != nil)
+        self.outputConnector = (lastInputLayout.input.connection != nil)
         self.middleHeight = lastInputLayout.totalSize.height
       } else {
         // The right edge for inline dummy/value inputs is the total width of all combined
@@ -196,7 +207,7 @@ extension DefaultBlockLayout {
     Resets all render properties to their default values.
     */
     fileprivate func resetRenderProperties() {
-      self.femaleOutputConnector = false
+      self.outputConnector = false
       self.isStatement = false
       self.rightEdge = 0
       self.topPadding = 0

--- a/Source/Layout/Default/DefaultLayoutConfig.swift
+++ b/Source/Layout/Default/DefaultLayoutConfig.swift
@@ -82,6 +82,13 @@ open class DefaultLayoutConfig: LayoutConfig {
   /// colors
   public static let BlockShadowBrightnessMultiplier = LayoutConfig.newPropertyKey()
 
+  /// [`Bool`] Flag indicating if blocks with no output or previous connection should be
+  /// rendered with a "hat".
+  public static let BlockStartHat = LayoutConfig.newPropertyKey()
+
+  /// [`Size`] The size to use when rendering a "start hat".
+  public static let BlockStartHatSize = LayoutConfig.newPropertyKey()
+
   /// [`Size`] Minimum size of the inline connector
   public static let MinimumInlineConnectorSize = LayoutConfig.newPropertyKey()
 
@@ -115,5 +122,8 @@ open class DefaultLayoutConfig: LayoutConfig {
     setFloat(0.5, for: DefaultLayoutConfig.BlockDisabledAlpha)
     setFloat(0.4, for: DefaultLayoutConfig.BlockShadowSaturationMultiplier)
     setFloat(1.2, for: DefaultLayoutConfig.BlockShadowBrightnessMultiplier)
+
+    setBool(false, for: DefaultLayoutConfig.BlockStartHat)
+    setSize(Size(100, 15), for: DefaultLayoutConfig.BlockStartHatSize)
   }
 }

--- a/Source/Layout/LayoutConfig.swift
+++ b/Source/Layout/LayoutConfig.swift
@@ -109,14 +109,14 @@ open class LayoutConfig: NSObject {
   // NOTE: Separate dictionaries were created for each type of value as casting specific values
   // from a Dictionary<PropertyKey, Any> is a big performance hit.
 
-  /// Dictionary mapping property keys to `Unit` values
-  private var _units = Dictionary<PropertyKey, Unit>()
-
-  /// Dictionary mapping property keys to `Size` values
-  private var _sizes = Dictionary<PropertyKey, Size>()
+  /// Dictionary mapping property keys to `Bool` values
+  private var _bools = Dictionary<PropertyKey, Bool>()
 
   /// Dictionary mapping property keys to `UIColor` values
   private var _colors = Dictionary<PropertyKey, UIColor>()
+
+  /// Dictionary mapping property keys to `Double` values
+  private var _doubles = Dictionary<PropertyKey, Double>()
 
   /// Dictionary mapping property keys to `EdgeInsets` values
   private var _edgeInsets = Dictionary<PropertyKey, EdgeInsets>()
@@ -124,11 +124,14 @@ open class LayoutConfig: NSObject {
   /// Dictionary mapping property keys to `CGFloat` values
   private var _floats = Dictionary<PropertyKey, CGFloat>()
 
-  /// Dictionary mapping property keys to `Double` values
-  private var _doubles = Dictionary<PropertyKey, Double>()
-
   /// Dictionary mapping property keys to `ScaledFont` values
   private var _fonts = Dictionary<PropertyKey, ScaledFont>()
+
+  /// Dictionary mapping property keys to `Size` values
+  private var _sizes = Dictionary<PropertyKey, Size>()
+
+  /// Dictionary mapping property keys to `Unit` values
+  private var _units = Dictionary<PropertyKey, Unit>()
 
   // MARK: - Initializers
 
@@ -178,6 +181,32 @@ open class LayoutConfig: NSObject {
   // MARK: - Configure Values
 
   /**
+   Maps a `Bool` value to a specific `PropertyKey`.
+
+   - parameter boolValue: The `Bool` value
+   - parameter key: The `PropertyKey` (e.g. `DefaultLayoutConfig.BlockStartHat`)
+   - returns: The `Bool` that was set.
+   */
+  @discardableResult
+  public func setBool(_ boolValue: Bool, for key: PropertyKey) -> Bool {
+    _bools[key] = boolValue
+    return boolValue
+  }
+
+  /**
+   Returns the `Bool` value that is mapped to a specific `PropertyKey`.
+
+   - parameter key: The `PropertyKey` (e.g. `DefaultLayoutConfig.BlockStartHat`)
+   - parameter defaultValue: [Optional] If no `Bool` was found for `key`, this value is
+   automatically assigned to `key` and used instead.
+   - returns: The `key`'s value
+   */
+  @inline(__always)
+  public func bool(for key: PropertyKey, defaultValue: Bool = false) -> Bool {
+    return _bools[key] ?? setBool(defaultValue, for: key)
+  }
+
+  /**
    Maps a `Double` value to a specific `PropertyKey`.
 
    - parameter doubleValue: The `Double` value
@@ -202,7 +231,7 @@ open class LayoutConfig: NSObject {
   public func double(for key: PropertyKey, defaultValue: Double = 0) -> Double {
     return _doubles[key] ?? setDouble(defaultValue, for: key)
   }
-  
+
   /**
    Maps a `UIColor` value to a specific `PropertyKey`.
 
@@ -228,7 +257,7 @@ open class LayoutConfig: NSObject {
   public func color(for key: PropertyKey, defaultValue: UIColor? = nil) -> UIColor? {
     return _colors[key] ?? (defaultValue != nil ? setColor(defaultValue, for: key) : nil)
   }
-  
+
   /**
    Maps a `EdgeInsets` value to a specific `PropertyKey`.
 
@@ -373,7 +402,7 @@ open class LayoutConfig: NSObject {
   {
     return size(for: key).workspaceSize
   }
-  
+
   /**
    Maps a `Unit` value to a specific `PropertyKey`.
 

--- a/Source/UI/Views/Default/DefaultBlockView+Render.swift
+++ b/Source/UI/Views/Default/DefaultBlockView+Render.swift
@@ -20,9 +20,11 @@ extension DefaultBlockView {
 
   /**
    Adds the path for drawing a next/previous notch.
+
+   Draws:
    ```
-   Draws: --
-            \_/
+   --
+     \_/
    ```
    - parameter path: The Bezier path to add to.
    - parameter drawLeftToRight: True if the path should be drawn from left-to-right. False if it
@@ -49,13 +51,15 @@ extension DefaultBlockView {
 
   /**
   Adds the path for drawing jagged teeth at the end of collapsed blocks.
+
+  Draws:
   ```
-  Draws: --
-           |
-            \
-            /
-           /
-           \
+  --
+    |
+     \
+     /
+    /
+    \
   ```
   - parameter path: The Bezier path to add to.
   */
@@ -69,8 +73,9 @@ extension DefaultBlockView {
 
   /**
    Adds the path for drawing a horizontal puzzle tab.
-   ```
+
    Draws:
+   ```
           |
         /\|
        |
@@ -129,11 +134,14 @@ extension DefaultBlockView {
 
   /**
    Adds the path for drawing the rounded top-left corner.
+
+   Draws:
    ```
-   Draws:   --
-           /
-          |
+     --
+    /
+   |
    ```
+   - parameter path: The Bezier path.
    - parameter blockCornerRadius: The block's corner radius, specified as a Workspace coordinate
    system unit.
    */
@@ -142,5 +150,24 @@ extension DefaultBlockView {
     path.addArc(withCenter: WorkspacePoint(x: blockCornerRadius, y: 0),
       radius: blockCornerRadius, startAngle: CGFloat(M_PI), endAngle: CGFloat(M_PI * 1.5),
       clockwise: true, relative: true)
+  }
+
+  /**
+   Adds the path for drawing a hat.
+
+   Draws:
+   ```
+    ---
+   /   \
+   ```
+   - parameter path: The Bezier path.
+   - parameter hatSize: The size of the hat, specified as a Workspace coordinate system size.
+   */
+  public final func addHat(toPath path: WorkspaceBezierPath, hatSize: WorkspaceSize)
+  {
+    path.addCurve(to: WorkspacePoint(x: hatSize.width, y: 0),
+                  controlPoint1: WorkspacePoint(x: hatSize.width * 0.3, y: -hatSize.height),
+                  controlPoint2: WorkspacePoint(x: hatSize.width * 0.7, y: -hatSize.height),
+                  relative: true)
   }
 }

--- a/Source/UI/Views/Default/DefaultBlockView.swift
+++ b/Source/UI/Views/Default/DefaultBlockView.swift
@@ -241,22 +241,29 @@ public final class DefaultBlockView: BlockView {
     let background = layout.background
     var previousBottomPadding: CGFloat = 0
     let xLeftEdgeOffset = background.leadingEdgeXOffset // Note: this is the right edge in RTL
+    let topEdgeOffset = background.leadingEdgeYOffset
     let notchWidth = layout.config.workspaceUnit(for: DefaultLayoutConfig.NotchWidth)
     let notchHeight = layout.config.workspaceUnit(for: DefaultLayoutConfig.NotchHeight)
     let puzzleTabWidth = layout.config.workspaceUnit(for: DefaultLayoutConfig.PuzzleTabWidth)
     let puzzleTabHeight = layout.config.workspaceUnit(for: DefaultLayoutConfig.PuzzleTabHeight)
+    let startHatSize = layout.config.workspaceSize(for: DefaultLayoutConfig.BlockStartHatSize)
 
-    path.moveTo(x: xLeftEdgeOffset, y: 0, relative: false)
+    path.moveTo(x: xLeftEdgeOffset, y: topEdgeOffset, relative: false)
 
     for i in 0 ..< background.rows.count {
       let row = background.rows[i]
 
       // DRAW THE TOP EDGES
 
-      if i == 0 && background.femalePreviousStatementConnector {
-        // Draw previous statement connector
-        addNotch(
-          toPath: path, drawLeftToRight: true, notchWidth: notchWidth, notchHeight: notchHeight)
+      if i == 0 {
+        if background.previousStatementConnector {
+          // Draw previous statement connector
+          addNotch(
+            toPath: path, drawLeftToRight: true, notchWidth: notchWidth, notchHeight: notchHeight)
+        } else if background.startHat {
+          // Draw hat for the block
+          addHat(toPath: path, hatSize: startHatSize)
+        }
       }
 
       path.addLineTo(
@@ -283,7 +290,8 @@ public final class DefaultBlockView: BlockView {
           toPath: path, drawLeftToRight: false, notchWidth: notchWidth, notchHeight: notchHeight)
 
         path.addLineTo(
-          x: xLeftEdgeOffset + row.statementIndent, y: path.currentWorkspacePoint.y, relative: false)
+          x: xLeftEdgeOffset + row.statementIndent, y: path.currentWorkspacePoint.y,
+          relative: false)
 
         // Inner-left side of "C"
         path.addLineTo(x: 0, y: row.middleHeight, relative: true)
@@ -297,8 +305,8 @@ public final class DefaultBlockView: BlockView {
           // If there is another row after this, the inner-floor of the "C" is drawn by the
           // right edge of the next row.
         }
-      } else if row.femaleOutputConnector {
-        // Draw female output connector and then the rest of the middle height
+      } else if row.outputConnector {
+        // Draw output connector and then the rest of the middle height
         let startingY = path.currentWorkspacePoint.y
         addPuzzleTab(toPath: path, drawTopToBottom: true,
           puzzleTabWidth: puzzleTabWidth, puzzleTabHeight: puzzleTabHeight)
@@ -321,18 +329,19 @@ public final class DefaultBlockView: BlockView {
 
     // DRAW THE BOTTOM EDGES
 
-    if background.maleNextStatementConnector {
+    if background.nextStatementConnector {
       path.addLineTo(
         x: xLeftEdgeOffset + notchWidth, y: path.currentWorkspacePoint.y, relative: false)
-      addNotch(toPath: path, drawLeftToRight: false, notchWidth: notchWidth, notchHeight: notchHeight)
+      addNotch(
+        toPath: path, drawLeftToRight: false, notchWidth: notchWidth, notchHeight: notchHeight)
     }
 
     path.addLineTo(x: xLeftEdgeOffset, y: path.currentWorkspacePoint.y, relative: false)
 
     // DRAW THE LEFT EDGES
 
-    if background.maleOutputConnector {
-      // Add male connector
+    if background.outputConnector {
+      // Add output connector
       path.addLineTo(x: 0, y: puzzleTabHeight - path.currentWorkspacePoint.y, relative: true)
 
       addPuzzleTab(toPath: path, drawTopToBottom: false,
@@ -438,8 +447,8 @@ public final class DefaultBlockView: BlockView {
   fileprivate func shadowColor(forColor color: UIColor, config: LayoutConfig) -> UIColor {
     var hsba = color.bky_hsba()
     hsba.saturation *= config.float(for: DefaultLayoutConfig.BlockShadowSaturationMultiplier)
-    hsba.brightness =
-      max(hsba.brightness * config.float(for: DefaultLayoutConfig.BlockShadowBrightnessMultiplier), 1)
+    hsba.brightness = max(
+      hsba.brightness * config.float(for: DefaultLayoutConfig.BlockShadowBrightnessMultiplier), 1)
     return UIColor(
       hue: hsba.hue, saturation: hsba.saturation, brightness: hsba.brightness, alpha: hsba.alpha)
   }


### PR DESCRIPTION
- Updated LayoutConfig to support Bool
- Fixed BlockLayout to render blocks with an empty message
- Removed male/female naming of block layout background properties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/265)
<!-- Reviewable:end -->
