### PR TITLE
- Added code for rendering MutatorLayouts

### DIFF
--- a/Source/UI/Views/LayoutView.swift
+++ b/Source/UI/Views/LayoutView.swift
@@ -76,7 +76,7 @@ open class LayoutView: UIView {
         UIView.animate(
           withDuration: duration,
           delay: 0,
-          options: [.beginFromCurrentState, .allowUserInteraction],
+          options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut],
           animations: code,
           completion: nil)
 


### PR DESCRIPTION
- Fixed render code so fields/inputs are evenly spaced within a block
- Updated UIView animation to use the same ease-in/out curve as layer animation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/284)
<!-- Reviewable:end -->
