### PR TITLE
- Added methods to Input for changing fields dynamically

### DIFF
--- a/Resources/Default/procedure_blocks.json
+++ b/Resources/Default/procedure_blocks.json
@@ -48,12 +48,12 @@
     "message0": "%1 %2",
     "args0": [
       {
-        "type": "input_dummy",
-        "name": "TOPROW"
-      },
-      {
         "type": "field_label",
         "name": "NAME"
+      },
+      {
+        "type": "input_dummy",
+        "name": "TOPROW"
       }
     ],
     "previousStatement": null,
@@ -66,12 +66,12 @@
     "message0": "%1 %2",
     "args0": [
       {
-        "type": "input_dummy",
-        "name": "TOPROW"
-      },
-      {
         "type": "field_label",
         "name": "NAME"
+      },
+      {
+        "type": "input_dummy",
+        "name": "TOPROW"
       }
     ],
     "output": null,

--- a/Source/Model/Input.swift
+++ b/Source/Model/Input.swift
@@ -97,7 +97,7 @@ public final class Input : NSObject {
   /// The name of the input.
   public let name: String
   /// A list of `Field` objects for the input.
-  public let fields: [Field]
+  public private(set) var fields: [Field]
   /// The `Block` that owns this input.
   public internal(set) weak var sourceBlock: Block? {
     didSet {
@@ -147,6 +147,42 @@ public final class Input : NSObject {
 
     for field in fields {
       field.sourceInput = self
+    }
+  }
+
+  // MARK: - Fields
+
+  /**
+   Append a field to the end of `self.fields`.
+
+   - parameter field: The `Field` to append.
+   */
+  public func appendField(_ field: Field) {
+    fields.append(field)
+    field.sourceInput = self
+  }
+
+  /**
+   Insert a field at the specified position.
+
+   - parameter field: The `Field` to insert.
+   - parameter index: The position to insert the field into `self.fields`.
+   */
+  public func insertField(_ field: Field, at index: Int) {
+    fields.insert(field, at: index)
+    field.sourceInput = self
+  }
+
+  /**
+   Remove a field from the input. If the field doesn't exist, nothing happens.
+
+   - parameter field: The `Field` to remove.
+   */
+  public func removeField(_ field: Field) {
+    if let index = fields.index(of: field) {
+      // Remove field
+      field.sourceInput = nil
+      fields.remove(at: index)
     }
   }
 }

--- a/Source/Model/MutatorProcedureCaller.swift
+++ b/Source/Model/MutatorProcedureCaller.swift
@@ -46,7 +46,19 @@ extension MutatorProcedureCaller: Mutator {
 
     // Update name label
     if let field = block.firstField(withName: "NAME") as? FieldLabel {
-      field.text = procedureName + (!parameters.isEmpty ? " with:" : "")
+      field.text = procedureName
+    }
+
+    // Update "with: " field
+    if let input = block.firstInput(withName: "TOPROW") {
+      let withField = block.firstField(withName: "WITH")
+      if parameters.isEmpty,
+        let field = withField
+      {
+        input.removeField(field)
+      } else if !parameters.isEmpty && withField == nil {
+        input.appendField(FieldLabel(name: "WITH", text: "with:"))
+      }
     }
 
     // Update parameters

--- a/Source/Model/XML/Toolbox+XML.swift
+++ b/Source/Model/XML/Toolbox+XML.swift
@@ -126,7 +126,6 @@ extension Toolbox {
           let callerNoReturnBlock = try factory.makeBlock(name: "procedures_callnoreturn")
           if let mutator = callerNoReturnBlock.mutator as? MutatorProcedureCaller {
             mutator.procedureName = "do something"
-            mutator.parameters = ["some parameter input"]
             try mutator.mutateBlock()
           }
           try category.addBlockTree(callerNoReturnBlock)


### PR DESCRIPTION
- Fixed block definitions for mutator procedure callers
- Changed MutatorProcedureCaller to create a new field for the 'with: ' label instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/300)
<!-- Reviewable:end -->
