### PR TITLE
- Re-added support for 'mutator' field in JSON block definitions

### DIFF
--- a/Resources/Default/logic_blocks.json
+++ b/Resources/Default/logic_blocks.json
@@ -16,7 +16,7 @@
         "name": "DO0"
       }
     ],
-    "extensions": ["controls_if_mutator"],
+    "mutator": "controls_if_mutator",
     "previousStatement": null,
     "nextStatement": null,
     "colour": 210,

--- a/Resources/Default/procedure_blocks.json
+++ b/Resources/Default/procedure_blocks.json
@@ -13,7 +13,7 @@
         "name": "PARAMS"
       }
     ],
-    "extensions": ["procedures_defnoreturn_mutator"],
+    "mutator": "procedures_defnoreturn_mutator",
     "colour": 290,
     "tooltip": "Creates a function with no output.",
     "helpUrl": "https://en.wikipedia.org/wiki/Procedure_%28computer_science%29"
@@ -40,7 +40,7 @@
         "align": "RIGHT"
       }
     ],
-    "extensions": ["procedures_defreturn_mutator"],
+    "mutator": "procedures_defreturn_mutator",
     "colour": 290,
     "tooltip": "Creates a function with an output.",
     "helpUrl": "https://en.wikipedia.org/wiki/Procedure_%28computer_science%29"
@@ -58,7 +58,7 @@
         "name": "TOPROW"
       }
     ],
-    "extensions": ["procedures_callnoreturn_mutator"],
+    "mutator": "procedures_callnoreturn_mutator",
     "previousStatement": null,
     "nextStatement": null,
     "colour": 290,
@@ -77,7 +77,7 @@
         "name": "TOPROW"
       }
     ],
-    "extensions": ["procedures_callreturn_mutator"],
+    "mutator": "procedures_callreturn_mutator",
     "output": null,
     "colour": 290,
     "helpUrl": "https://en.wikipedia.org/wiki/Procedure_%28computer_science%29"
@@ -96,7 +96,7 @@
         "name": "VALUE"
       }
     ],
-    "extensions": ["procedures_ifreturn_mutator"],
+    "mutator": "procedures_ifreturn_mutator",
     "inputsInline": true,
     "previousStatement": null,
     "nextStatement": null,

--- a/Source/Model/BlockExtension.swift
+++ b/Source/Model/BlockExtension.swift
@@ -44,7 +44,7 @@ public final class BlockExtensionClosure: NSObject, BlockExtension {
   // MARK: - Properties
 
   /// The closure that is executed by this extension during `Block` initialization.
-  private var _closure: (Block) throws -> Void
+  private var _closure: (Block) -> Void
 
   // MARK: - Initializers
 
@@ -53,7 +53,7 @@ public final class BlockExtensionClosure: NSObject, BlockExtension {
 
    - parameter closure: Code that should be run for a `Block` during its initialization.
    */
-  public init(_ closure: @escaping (Block) throws -> Void) {
+  public init(_ closure: @escaping (Block) -> Void) {
     _closure = closure
   }
 
@@ -65,6 +65,6 @@ public final class BlockExtensionClosure: NSObject, BlockExtension {
    - parameter block: The block that is used for the extension code closure.
    */
   public func run(block: Block) throws {
-    try _closure(block)
+    _closure(block)
   }
 }

--- a/Source/Model/JSON/BlockJSONFile.swift
+++ b/Source/Model/JSON/BlockJSONFile.swift
@@ -48,33 +48,29 @@ extension BlockJSONFile {
     return fileLocations
   }
 
+  /// Dictionary mapping extension names to `Mutator`, for all blocks specified under
+  /// `self.fileLocations`.
+  public var mutators: [String: Mutator] {
+    var mutators = [String: Mutator]()
+
+    if contains(.logicDefault) {
+      mutators["controls_if_mutator"] = MutatorIfElse()
+    }
+    if contains(.procedureDefault) {
+      mutators["procedures_defnoreturn_mutator"] = MutatorProcedureDefinition(returnsValue: false)
+      mutators["procedures_defreturn_mutator"] = MutatorProcedureDefinition(returnsValue: true)
+      mutators["procedures_callnoreturn_mutator"] = MutatorProcedureCaller()
+      mutators["procedures_callreturn_mutator"] = MutatorProcedureCaller()
+      mutators["procedures_ifreturn_mutator"] = MutatorProcedureIfReturn()
+    }
+
+    return mutators
+  }
+
   /// Dictionary mapping extension names to `BlockExtension`, for all blocks specified under
   /// `self.fileLocations`.
   public var blockExtensions: [String: BlockExtension] {
-    var extensions = [String: BlockExtension]()
-
-    if contains(.logicDefault) {
-      extensions["controls_if_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorIfElse())
-      }
-    }
-    if contains(.procedureDefault) {
-      extensions["procedures_defnoreturn_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorProcedureDefinition(returnsValue: false))
-      }
-      extensions["procedures_defreturn_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorProcedureDefinition(returnsValue: true))
-      }
-      extensions["procedures_callnoreturn_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorProcedureCaller())
-      }
-      extensions["procedures_callreturn_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorProcedureCaller())
-      }
-      extensions["procedures_ifreturn_mutator"] = BlockExtensionClosure { block in
-        try block.setMutator(MutatorProcedureIfReturn())
-      }
-    }
+    let extensions = [String: BlockExtension]()
 
     return extensions
   }

--- a/Source/Model/Mutator.swift
+++ b/Source/Model/Mutator.swift
@@ -49,8 +49,9 @@ public protocol Mutator : class {
   /**
    Updates this mutator's internal state, using the XML from the block.
 
+   - paramter xml: The XML of the block.
    - note: This method call does not actually mutate the block.
-   `performMutation()` must be explicitly called after this.
+   `mutateBlock()` must be explicitly called after this.
    */
   func update(fromXML xml: AEXMLElement)
 


### PR DESCRIPTION
- Updated BlockExtensionClosure to be exposed in Obj-C

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/327)
<!-- Reviewable:end -->
