### PR TITLE
- Added support for grouping, merging, and discarding events

### DIFF
--- a/Source/Control/EventManager.swift
+++ b/Source/Control/EventManager.swift
@@ -40,15 +40,25 @@ public final class EventManager: NSObject {
   /// Shared instance.
   public static let sharedInstance = EventManager()
 
-  /// Sequential list of events queued up for firing
+  /// Sequential list of events queued up for firing.
   public private(set) var pendingEvents = [BlocklyEvent]()
 
   /// Flag that determines if the event manager is allowing any new events to be queued via
   /// `addPendingEvent(:)`. Defaults to `true`.
-  public var isEnabled = true
+  public var isEnabled: Bool = true
 
-  /// Objects listening to event fires
+  /// The current group ID that is automatically assigned to new events with no group ID.
+  public private(set) var groupID: String?
+
+  /// Objects listening to event fires.
   private var _listeners = WeakSet<EventManagerListener>()
+
+  /// Flag indicating if events are currently being fired.
+  private var _firingEvents: Bool = false
+
+  /// Flag that determines if `firePendingEvents()` should be called again immediately after
+  /// it has been called.
+  private var _firePendingEventsAgain: Bool = false
 
   // MARK: - Events
 
@@ -56,11 +66,18 @@ public final class EventManager: NSObject {
    Queues an event to be fired in the future (via `firePendingEvents()`). However, this event will
    not be queued if `self.isEnabled` is set to `false`.
 
+   If `event.groupID` is `nil`, it is automatically assigned the value of `self.groupID`, by this
+   method.
+
    - parameter event: The `BlocklyEvent` to queue.
    */
   public func addPendingEvent(_ event: BlocklyEvent) {
     guard isEnabled else {
       return
+    }
+
+    if event.groupID == nil {
+      event.groupID = groupID
     }
 
     pendingEvents.append(event)
@@ -70,15 +87,81 @@ public final class EventManager: NSObject {
    Fires all pending events.
    */
   public func firePendingEvents() {
-    // TODO:(#272) Merge similar events before firing them.
+    guard !_firingEvents else {
+      // The event manager is currently firing events. Schedule it to fire the next batch of events
+      // after it is done its current batch.
+      _firePendingEventsAgain = true
+      return
+    }
 
-    for event in pendingEvents {
+    _firingEvents = true
+
+    // Work off copy of the current batch of events, so we can clear the queue immediately.
+    let eventQueue = pendingEvents.merged().filterDiscardable()
+    pendingEvents.removeAll()
+
+    // Fire events
+    for event in eventQueue {
       for listener in _listeners {
         listener.eventManager(self, didFireEvent: event)
       }
     }
 
-    pendingEvents.removeAll()
+    _firingEvents = false
+
+    if _firePendingEventsAgain {
+      // Immediately fire the next batch of events
+      _firePendingEventsAgain = false
+      firePendingEvents()
+    }
+  }
+
+  // MARK: - Grouping
+
+  /**
+   Starts a group by setting `self.groupID` to a new UUID. Each new pending event will automatically
+   be assigned to this group ID, if it is not already assigned to a group ID.
+   */
+  public func startGroup() {
+    groupID = UUID().uuidString
+  }
+
+  /**
+   Starts a group by setting `self.groupID` to a given group ID. Each new pending event will
+   automatically be assigned to this group ID, if it is not already assigned to a group ID.
+
+   - parameter groupID: The groupID to assign.
+   */
+  public func startGroup(groupID: String) {
+    self.groupID = groupID
+  }
+
+  /**
+   Stops the current group by setting `self.groupID` to `nil`. Each new pending event will no
+   longer be automatically assigned to a group ID.
+   */
+  public func stopGroup() {
+    groupID = nil
+  }
+
+  /**
+   Convenience method that starts a new group, executes a given closure, stops the group, and then
+   fires all pending events.
+
+   - parameter closure: The closure to execute.
+   - note: This method guarantees a group is started, stopped, and all pending events are fired,
+   regardless if the given closure throws an error.
+   */
+  public func groupAndFireEvents(forClosure closure: () throws -> Void) rethrows {
+    startGroup()
+
+    defer {
+      // This is guaranteed to run after the execution of `closure`, regardless if it fails or not.
+      stopGroup()
+      firePendingEvents()
+    }
+
+    try closure()
   }
 
   // MARK: - Listeners

--- a/Source/Control/ProcedureCoordinator.swift
+++ b/Source/Control/ProcedureCoordinator.swift
@@ -334,8 +334,8 @@ public class ProcedureCoordinator: NSObject {
         let mutatorCallerLayout = callerBlock.layout?.mutatorLayout as? MutatorProcedureCallerLayout
       {
         // NOTE: mutatorLayout is used here since it will preserve connections for existing inputs
-        // if the parameters have been reordered.
-        mutatorCallerLayout.preserveCurrentInputConnections()
+        // if the parameters have been reordered (when starting a new mutation session).
+        mutatorCallerLayout.beginMutationSession()
         mutatorCallerLayout.procedureName = newName
         mutatorCallerLayout.parameters = parameters
 
@@ -375,7 +375,7 @@ extension ProcedureCoordinator: WorkspaceListener {
     }
   }
 
-  public func workspace(_ workspace: Workspace, willRemoveBlock block: Block) {
+  public func workspace(_ workspace: Workspace, didRemoveBlock block: Block) {
     if block.isProcedureDefinition {
       untrackProcedureDefinitionBlock(block)
     } else if block.isProcedureCaller {

--- a/Source/Control/ProcedureCoordinator.swift
+++ b/Source/Control/ProcedureCoordinator.swift
@@ -334,8 +334,8 @@ public class ProcedureCoordinator: NSObject {
         let mutatorCallerLayout = callerBlock.layout?.mutatorLayout as? MutatorProcedureCallerLayout
       {
         // NOTE: mutatorLayout is used here since it will preserve connections for existing inputs
-        // if the parameters have been reordered (when starting a new mutation session).
-        mutatorCallerLayout.beginMutationSession()
+        // if the parameters have been reordered.
+        mutatorCallerLayout.preserveCurrentInputConnections()
         mutatorCallerLayout.procedureName = newName
         mutatorCallerLayout.parameters = parameters
 

--- a/Source/Layout/BlockGroupLayout.swift
+++ b/Source/Layout/BlockGroupLayout.swift
@@ -207,9 +207,9 @@ open class BlockGroupLayout: Layout {
       }
 
       if let block = blockLayouts.first?.block {
-        let event = MoveEvent(workspace: workspaceLayout.workspace, block: block)
+        let event = BlockMoveEvent(workspace: workspaceLayout.workspace, block: block)
         updatePosition()
-        try? event.recordNewValues(fromBlock: block)
+        event.recordNewValues()
         EventManager.sharedInstance.addPendingEvent(event)
       } else {
         bky_debugPrint("An empty block group was moved. This may be the result of abnormal state.")

--- a/Source/Layout/FieldAngleLayout.swift
+++ b/Source/Layout/FieldAngleLayout.swift
@@ -64,7 +64,7 @@ open class FieldAngleLayout: FieldLayout {
    */
   open func updateAngle(fromText text: String) {
     if let newAngle = Int(text) { // Only update it if it's a valid value
-      captureAndFireChangeEvent {
+      captureChangeEvent {
         // Setting to a new angle automatically fires a listener to update the layout
         fieldAngle.angle = newAngle
       }

--- a/Source/Layout/FieldCheckboxLayout.swift
+++ b/Source/Layout/FieldCheckboxLayout.swift
@@ -64,7 +64,7 @@ open class FieldCheckboxLayout: FieldLayout {
    - parameter checked: The value used to update `self.fieldCheckbox`.
    */
   open func updateCheckbox(_ checked: Bool) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       // Setting to a new checkbox value automatically fires a listener to update the layout
       fieldCheckbox.checked = checked
     }

--- a/Source/Layout/FieldColorLayout.swift
+++ b/Source/Layout/FieldColorLayout.swift
@@ -62,7 +62,7 @@ open class FieldColorLayout: FieldLayout {
    - parameter color: The value used to update `self.fieldColor`.
    */
   open func updateColor(_ color: UIColor) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       // Setting to a new color automatically fires a listener to update the layout
       fieldColor.color = color
     }

--- a/Source/Layout/FieldDateLayout.swift
+++ b/Source/Layout/FieldDateLayout.swift
@@ -77,7 +77,7 @@ open class FieldDateLayout: FieldLayout {
    - parameter date: The value used to update `self.fieldDate`.
    */
   open func updateDate(_ date: Date) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       // Setting to a new date automatically fires a listener to update the layout
       fieldDate.date = date
     }

--- a/Source/Layout/FieldDropdownLayout.swift
+++ b/Source/Layout/FieldDropdownLayout.swift
@@ -74,7 +74,7 @@ open class FieldDropdownLayout: FieldLayout {
    - parameter selectedIndex: The value used to update `self.fieldDropdown.selectedIndex`.
    */
   open func updateSelectedIndex(_ selectedIndex: Int) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       // Setting to a new index automatically fires a listener to update the layout
       fieldDropdown.selectedIndex = selectedIndex
     }

--- a/Source/Layout/FieldInputLayout.swift
+++ b/Source/Layout/FieldInputLayout.swift
@@ -75,7 +75,7 @@ open class FieldInputLayout: FieldLayout {
    - parameter text: The value used to update `self.fieldInput`.
    */
   open func updateText(_ text: String) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       // Setting to new text automatically fires a listener to update the layout
       fieldInput.text = text
       currentTextValue = fieldInput.text

--- a/Source/Layout/FieldLayout.swift
+++ b/Source/Layout/FieldLayout.swift
@@ -99,12 +99,13 @@ open class FieldLayout: Layout {
   // MARK: - Change Events
 
   /**
-   Automatically captures and fires a `ChangeEvent` for `self.field`, based on its state before
-   and after running a given closure block.
+   Automatically captures a `ChangeEvent` for `self.field`, based on its state before
+   and after running a given closure block. This event is then added to the pending events queue
+   on `EventManager.sharedInstance`.
 
    - parameter closure: A closure to execute, that will change the state of `self.field`.
    */
-  open func captureAndFireChangeEvent(_ closure: () -> Void) {
+  open func captureChangeEvent(_ closure: () -> Void) {
     if let workspace = firstAncestor(ofType: WorkspaceLayout.self)?.workspace,
       let block = field.sourceInput?.sourceBlock
     {
@@ -121,7 +122,6 @@ open class FieldLayout: Layout {
           workspace: workspace, block: block, field: field,
           oldValue: anOldValue, newValue: aNewValue)
         EventManager.sharedInstance.addPendingEvent(event)
-        EventManager.sharedInstance.firePendingEvents()
       }
     } else {
       // Just run update

--- a/Source/Layout/FieldNumberLayout.swift
+++ b/Source/Layout/FieldNumberLayout.swift
@@ -71,7 +71,7 @@ open class FieldNumberLayout: FieldLayout {
    automatically sets `self.currentTextValue` to `self.fieldNumber.textValue`.
    */
   open func setValueFromLocalizedText(_ text: String) {
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       fieldNumber.setValueFromLocalizedText(text)
 
       // Update `currentTextValue` to match the current localized text value of `fieldNumber`,

--- a/Source/Layout/FieldVariableLayout.swift
+++ b/Source/Layout/FieldVariableLayout.swift
@@ -123,7 +123,7 @@ open class FieldVariableLayout: FieldLayout {
         return
       }
 
-      captureAndFireChangeEvent {
+      captureChangeEvent {
         do {
           try fieldVariable.setVariable(variable)
         } catch let error {
@@ -140,7 +140,7 @@ open class FieldVariableLayout: FieldLayout {
    */
   open func renameVariable(to newName: String) {
     let oldName = self.variable
-    captureAndFireChangeEvent {
+    captureChangeEvent {
       do {
         try fieldVariable.setVariable(newName)
       } catch let error {

--- a/Source/Layout/MutatorIfElseLayout.swift
+++ b/Source/Layout/MutatorIfElseLayout.swift
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import AEXML
 import Foundation
 
 /**
@@ -54,15 +55,6 @@ public class MutatorIfElseLayout : MutatorLayout {
     self.contentSize = WorkspaceSize(width: 32, height: 32)
   }
 
-  public override func beginMutationSession() {
-    // For all inputs created by this mutator, save the currently connected target connection for
-    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-    // connections remain connected to that original input, as long as the input still exists
-    // post-mutation.
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(fromInputs: mutatorIfElse.sortedMutatorInputs())
-  }
-
   public override func performMutation() throws {
     guard let block = mutatorIfElse.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -95,5 +87,25 @@ public class MutatorIfElseLayout : MutatorLayout {
       layoutCoordinator.blockBumper
         .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
     }
+  }
+
+  public override func performMutation(fromXML xml: AEXMLElement) throws {
+    // Since this call is most likely being triggered from an event, clear all saved target
+    // connections, before updating via XML
+    mutatorHelper.clearSavedTargetConnections()
+    try super.performMutation(fromXML: xml)
+  }
+
+  // MARK: - Pre-Mutation
+
+  /**
+   For all inputs created by this mutator, save the currently connected target connection for
+   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+   connections remain connected to that original input, as long as the input still exists
+   post-mutation.
+   */
+  public func preserveCurrentInputConnections() {
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(fromInputs: mutatorIfElse.sortedMutatorInputs())
   }
 }

--- a/Source/Layout/MutatorIfElseLayout.swift
+++ b/Source/Layout/MutatorIfElseLayout.swift
@@ -54,6 +54,15 @@ public class MutatorIfElseLayout : MutatorLayout {
     self.contentSize = WorkspaceSize(width: 32, height: 32)
   }
 
+  public override func beginMutationSession() {
+    // For all inputs created by this mutator, save the currently connected target connection for
+    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+    // connections remain connected to that original input, as long as the input still exists
+    // post-mutation.
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(fromInputs: mutatorIfElse.sortedMutatorInputs())
+  }
+
   public override func performMutation() throws {
     guard let block = mutatorIfElse.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -71,7 +80,7 @@ public class MutatorIfElseLayout : MutatorLayout {
       fromInputs: inputs, layoutCoordinator: layoutCoordinator)
 
     // Update the definition of the block
-    try captureAndFireChangeEvent {
+    try captureChangeEvent {
       try mutatorIfElse.mutateBlock()
     }
 
@@ -86,18 +95,5 @@ public class MutatorIfElseLayout : MutatorLayout {
       layoutCoordinator.blockBumper
         .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
     }
-  }
-
-  // MARK: - Pre-Mutation
-
-  /**
-   For all inputs created by this mutator, save the currently connected target connection for
-   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-   connections remain connected to that original input, as long as the input still exists
-   post-mutation.
-   */
-  public func preserveCurrentInputConnections() {
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(fromInputs: mutatorIfElse.sortedMutatorInputs())
   }
 }

--- a/Source/Layout/MutatorLayout.swift
+++ b/Source/Layout/MutatorLayout.swift
@@ -45,24 +45,6 @@ open class MutatorLayout: Layout {
   // MARK: - Abstract
 
   /**
-   Performs any work prior to starting a new mutation "session". A session is defined as performing
-   multiple mutations together. An example of a session would be opening an "if/else" mutator
-   popover, performing multiple mutations to update the number of else-if and else statements, and
-   then closing the mutator popover.
-
-   With this method, a mutator layout can keep track of any existing state of a block that should
-   persist as mutations are performed on the block. For example, an "if/else" mutator layout could
-   use this method to store the existing connections of the block and then during
-   `performMutation()`, try to restore the connections of the block even as the number of else-if
-   and else statements are updated.
-
-   The default implementation does nothing. Subclasses may override this method to specify
-   behavior for their mutators.
-   */
-  open func beginMutationSession() {
-  }
-
-  /**
    Performs any work required to maintain the integrity of the layout hierarchy, in addition to
    calling `mutator.mutateBlock()`.
 

--- a/Source/Layout/MutatorLayout.swift
+++ b/Source/Layout/MutatorLayout.swift
@@ -45,6 +45,24 @@ open class MutatorLayout: Layout {
   // MARK: - Abstract
 
   /**
+   Performs any work prior to starting a new mutation "session". A session is defined as performing
+   multiple mutations together. An example of a session would be opening an "if/else" mutator
+   popover, performing multiple mutations to update the number of else-if and else statements, and
+   then closing the mutator popover.
+
+   With this method, a mutator layout can keep track of any existing state of a block that should
+   persist as mutations are performed on the block. For example, an "if/else" mutator layout could
+   use this method to store the existing connections of the block and then during
+   `performMutation()`, try to restore the connections of the block even as the number of else-if
+   and else statements are updated.
+
+   The default implementation does nothing. Subclasses may override this method to specify
+   behavior for their mutators.
+   */
+  open func beginMutationSession() {
+  }
+
+  /**
    Performs any work required to maintain the integrity of the layout hierarchy, in addition to
    calling `mutator.mutateBlock()`.
 
@@ -72,12 +90,13 @@ open class MutatorLayout: Layout {
   // MARK: - Change Event
 
   /**
-   Automatically captures and fires a `ChangeEvent` for `self.mutator`, based on its state before
-   and after running a given closure block.
+   Automatically captures a `ChangeEvent` for `self.mutator`, based on its state before
+   and after running a given closure block. This event is then added to the pending events queue
+   on `EventManager.sharedInstance`.
 
    - parameter closure: A closure to execute, that will change the state of `self.mutator`.
    */
-  public func captureAndFireChangeEvent(closure: () throws -> Void) rethrows {
+  public func captureChangeEvent(closure: () throws -> Void) rethrows {
     if let workspace = layoutCoordinator?.workspaceLayout.workspace,
       let block = mutator.block
     {
@@ -90,7 +109,6 @@ open class MutatorLayout: Layout {
         let event = ChangeEvent.mutateEvent(
           workspace: workspace, block: block, oldValue: oldValue, newValue: newValue)
         EventManager.sharedInstance.addPendingEvent(event)
-        EventManager.sharedInstance.firePendingEvents()
       }
     } else {
       // Just run closure

--- a/Source/Layout/MutatorProcedureDefinitionLayout.swift
+++ b/Source/Layout/MutatorProcedureDefinitionLayout.swift
@@ -64,6 +64,16 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
     self.contentSize = WorkspaceSize(width: 32, height: 32)
   }
 
+  public override func beginMutationSession() {
+    // For all inputs created by this mutator, save the currently connected target connection for
+    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+    // connections remain connected to that original input, as long as the input still exists
+    // post-mutation.
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(
+      fromInputs: mutatorProcedureDefinition.sortedMutatorInputs())
+  }
+
   public override func performMutation() throws {
     guard let block = mutatorProcedureDefinition.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -81,7 +91,7 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
       fromInputs: inputs, layoutCoordinator: layoutCoordinator)
 
     // Update the definition of the block
-    try captureAndFireChangeEvent {
+    try captureChangeEvent {
       try mutatorProcedureDefinition.mutateBlock()
     }
 
@@ -102,20 +112,6 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
     NotificationCenter.default.post(
       name: MutatorProcedureDefinitionLayout.NotificationDidPerformMutation,
       object: self)
-  }
-
-  // MARK: - Pre-Mutation
-
-  /**
-   For all inputs created by this mutator, save the currently connected target connection for
-   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-   connections remain connected to that original input, as long as the input still exists
-   post-mutation.
-   */
-  public func preserveCurrentInputConnections() {
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(
-      fromInputs: mutatorProcedureDefinition.sortedMutatorInputs())
   }
 
   // MARK: - Queries

--- a/Source/Layout/MutatorProcedureDefinitionLayout.swift
+++ b/Source/Layout/MutatorProcedureDefinitionLayout.swift
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import AEXML
 import Foundation
 
 /**
@@ -64,16 +65,6 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
     self.contentSize = WorkspaceSize(width: 32, height: 32)
   }
 
-  public override func beginMutationSession() {
-    // For all inputs created by this mutator, save the currently connected target connection for
-    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-    // connections remain connected to that original input, as long as the input still exists
-    // post-mutation.
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(
-      fromInputs: mutatorProcedureDefinition.sortedMutatorInputs())
-  }
-
   public override func performMutation() throws {
     guard let block = mutatorProcedureDefinition.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -112,6 +103,27 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
     NotificationCenter.default.post(
       name: MutatorProcedureDefinitionLayout.NotificationDidPerformMutation,
       object: self)
+  }
+
+  public override func performMutation(fromXML xml: AEXMLElement) throws {
+    // Since this call is most likely being triggered from an event, clear all saved target
+    // connections, before updating via XML
+    mutatorHelper.clearSavedTargetConnections()
+    try super.performMutation(fromXML: xml)
+  }
+
+  // MARK: - Pre-Mutation
+
+  /**
+   For all inputs created by this mutator, save the currently connected target connection for
+   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+   connections remain connected to that original input, as long as the input still exists
+   post-mutation.
+   */
+  public func preserveCurrentInputConnections() {
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(
+      fromInputs: mutatorProcedureDefinition.sortedMutatorInputs())
   }
 
   // MARK: - Queries

--- a/Source/Layout/MutatorProcedureIfReturnLayout.swift
+++ b/Source/Layout/MutatorProcedureIfReturnLayout.swift
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import AEXML
 import Foundation
 
 /**
@@ -59,16 +60,6 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
     self.contentSize = WorkspaceSize.zero
   }
 
-  public override func beginMutationSession() {
-    // For all inputs created by this mutator, save the currently connected target connection for
-    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-    // connections remain connected to that original input, as long as the input still exists
-    // post-mutation.
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(
-      fromInputs: mutatorProcedureIfReturn.sortedMutatorInputs())
-  }
-
   public override func performMutation() throws {
     guard let block = mutatorProcedureIfReturn.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -108,6 +99,27 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
           .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
       }
     }
+  }
+
+  public override func performMutation(fromXML xml: AEXMLElement) throws {
+    // Since this call is most likely being triggered from an event, clear all saved target
+    // connections, before updating via XML
+    mutatorHelper.clearSavedTargetConnections()
+    try super.performMutation(fromXML: xml)
+  }
+
+  // MARK: - Pre-Mutation
+
+  /**
+   For all inputs created by this mutator, save the currently connected target connection for
+   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+   connections remain connected to that original input, as long as the input still exists
+   post-mutation.
+   */
+  public func preserveCurrentInputConnections() {
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(
+      fromInputs: mutatorProcedureIfReturn.sortedMutatorInputs())
   }
 
   // MARK: - Validation

--- a/Source/Layout/MutatorProcedureIfReturnLayout.swift
+++ b/Source/Layout/MutatorProcedureIfReturnLayout.swift
@@ -59,6 +59,16 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
     self.contentSize = WorkspaceSize.zero
   }
 
+  public override func beginMutationSession() {
+    // For all inputs created by this mutator, save the currently connected target connection for
+    // each of them. Any subsequent call to `performMutation()` will ensure that these saved target
+    // connections remain connected to that original input, as long as the input still exists
+    // post-mutation.
+    mutatorHelper.clearSavedTargetConnections()
+    mutatorHelper.saveTargetConnections(
+      fromInputs: mutatorProcedureIfReturn.sortedMutatorInputs())
+  }
+
   public override func performMutation() throws {
     guard let block = mutatorProcedureIfReturn.block,
       let layoutCoordinator = self.layoutCoordinator else
@@ -78,7 +88,7 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
       try mutatorHelper.removeShadowBlocksInReverseOrder(
         fromInputs: inputs, layoutCoordinator: layoutCoordinator)
 
-      try captureAndFireChangeEvent {
+      try captureChangeEvent {
         // Update the definition of the block
         try mutatorProcedureIfReturn.mutateBlock()
       }
@@ -98,20 +108,6 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
           .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
       }
     }
-  }
-
-  // MARK: - Pre-Mutation
-
-  /**
-   For all inputs created by this mutator, save the currently connected target connection for
-   each of them. Any subsequent call to `performMutation()` will ensure that these saved target
-   connections remain connected to that original input, as long as the input still exists
-   post-mutation.
-   */
-  public func preserveCurrentInputConnections() {
-    mutatorHelper.clearSavedTargetConnections()
-    mutatorHelper.saveTargetConnections(
-      fromInputs: mutatorProcedureIfReturn.sortedMutatorInputs())
   }
 
   // MARK: - Validation

--- a/Source/Layout/WorkspaceLayoutCoordinator.swift
+++ b/Source/Layout/WorkspaceLayoutCoordinator.swift
@@ -264,11 +264,11 @@ open class WorkspaceLayoutCoordinator: NSObject {
     }
 
     let inferiorBlock = connection.isInferior ? sourceBlock : targetBlock
-    let event = MoveEvent(workspace: workspaceLayout.workspace, block: inferiorBlock)
+    let event = BlockMoveEvent(workspace: workspaceLayout.workspace, block: inferiorBlock)
 
     connection.disconnect()
 
-    try event.recordNewValues(fromBlock: inferiorBlock)
+    event.recordNewValues()
     EventManager.sharedInstance.addPendingEvent(event)
 
     self.didChangeTarget(forConnection: connection, oldTarget: oldTarget)
@@ -322,7 +322,7 @@ open class WorkspaceLayoutCoordinator: NSObject {
     }
 
     let inferiorBlock = connection1.isInferior ? sourceBlock1 : sourceBlock2
-    let event = MoveEvent(workspace: workspaceLayout.workspace, block: inferiorBlock)
+    let event = BlockMoveEvent(workspace: workspaceLayout.workspace, block: inferiorBlock)
 
     let oldTarget1 = connection1.targetConnection
     let oldTarget2 = connection2.targetConnection
@@ -331,7 +331,7 @@ open class WorkspaceLayoutCoordinator: NSObject {
     didChangeTarget(forConnection: connection1, oldTarget: oldTarget1)
     didChangeTarget(forConnection: connection2, oldTarget: oldTarget2)
 
-    try event.recordNewValues(fromBlock: inferiorBlock)
+    event.recordNewValues()
     EventManager.sharedInstance.addPendingEvent(event)
 
     // TODO:(#272) When events are implemented, re-visit whether these notifications should be
@@ -796,11 +796,7 @@ extension WorkspaceLayoutCoordinator: WorkspaceListener {
     }
   }
 
-  public func workspace(_ workspace: Workspace, willRemoveBlock block: Block) {
-    if let layout = block.layout {
-      removeNameManager(fromBlockLayout: layout)
-    }
-
+  public func workspace(_ workspace: Workspace, didRemoveBlock block: Block) {
     if !block.topLevel {
       // We only need to remove layout trees for top-level blocks
       return

--- a/Source/Model/Event/BlocklyUIEvent.swift
+++ b/Source/Model/Event/BlocklyUIEvent.swift
@@ -83,7 +83,7 @@ public final class BlocklyUIEvent: BlocklyEvent {
    - parameter newValue: [Optional] The value after the event. Booleans are mapped to `true` and
    `false`. Defaults to `nil`.
    */
-  public required init(element: Element, workspace: Workspace, block: Block?,
+  public init(element: Element, workspace: Workspace, block: Block?,
                        oldValue: String? = nil, newValue: String? = nil)
   {
     self.element = element
@@ -100,7 +100,7 @@ public final class BlocklyUIEvent: BlocklyEvent {
    - throws:
    `BlocklyError`: Thrown when the JSON could not be parsed into a `BlocklyUIEvent` object.
    */
-  public required init(json: [String: Any]) throws {
+  public init(json: [String: Any]) throws {
     if let element = Element(string: json[BlocklyEvent.JSON_ELEMENT] as? String ?? "") {
       self.element = element
     } else {

--- a/Source/Model/Event/CreateEvent.swift
+++ b/Source/Model/Event/CreateEvent.swift
@@ -43,7 +43,7 @@ public final class CreateEvent: BlocklyEvent {
    - throws:
    `BlocklyError`: Thrown if the given block tree could not be serialized into xml.
    */
-  public required init(workspace: Workspace, block: Block) throws {
+  public init(workspace: Workspace, block: Block) throws {
     xml = try block.toXML()
     blockIDs = block.allBlocksForTree().map { $0.uuid }
 
@@ -58,7 +58,7 @@ public final class CreateEvent: BlocklyEvent {
    - throws:
    `BlocklyError`: Thrown when the JSON could not be parsed into a `CreateEvent` object.
    */
-  public required init(json: [String: Any]) throws {
+  public init(json: [String: Any]) throws {
     xml = json[BlocklyEvent.JSON_XML] as? String ?? ""
     blockIDs = json[BlocklyEvent.JSON_IDS] as? [String] ?? []
     try super.init(type: CreateEvent.EVENT_TYPE, json: json)

--- a/Source/Model/Event/DeleteEvent.swift
+++ b/Source/Model/Event/DeleteEvent.swift
@@ -42,7 +42,7 @@ public final class DeleteEvent: BlocklyEvent {
    - throws:
    `BlocklyError`: Thrown if the given block tree could not be serialized into xml.
    */
-  public required init(workspace: Workspace, block: Block) throws {
+  public init(workspace: Workspace, block: Block) throws {
     oldXML = try block.toXML()
     blockIDs = block.allBlocksForTree().map { $0.uuid }
 
@@ -57,7 +57,7 @@ public final class DeleteEvent: BlocklyEvent {
    - throws:
    `BlocklyError`: Thrown when the JSON could not be parsed into a `DeleteEvent` object.
    */
-  public required init(json: [String: Any]) throws {
+  public init(json: [String: Any]) throws {
     oldXML = json[BlocklyEvent.JSON_OLD_VALUE] as? String ?? "" // Not usually used.
     blockIDs = json[BlocklyEvent.JSON_IDS] as? [String] ?? []
 

--- a/Source/Model/Workspace.swift
+++ b/Source/Model/Workspace.swift
@@ -29,12 +29,12 @@ public protocol WorkspaceListener: class {
   func workspace(_ workspace: Workspace, didAddBlock block: Block)
 
   /**
-   Event that is called when a block will be removed from a workspace.
+   Event that is called when a block has been removed from a workspace.
 
-   - parameter workspace: The workspace that will remove a block.
-   - parameter block: The block that will be removed.
+   - parameter workspace: The workspace that removed a block.
+   - parameter block: The block that was removed.
    */
-  func workspace(_ workspace: Workspace, willRemoveBlock block: Block)
+  func workspace(_ workspace: Workspace, didRemoveBlock block: Block)
 }
 
 /**
@@ -197,19 +197,19 @@ open class Workspace : NSObject {
         "to being removed from the workspace")
     }
 
-    var blocksToRemove = [Block]()
+    var removedBlocks = [Block]()
 
-    // Gather all blocks to be removed and notify the delegate
+    // Remove blocks from workspace
     for block in rootBlock.allBlocksForTree() {
       if containsBlock(block) {
-        blocksToRemove.append(block)
-        listeners.forEach { $0.workspace(self, willRemoveBlock: block) }
+        removedBlocks.append(block)
+        allBlocks[block.uuid] = nil
       }
     }
 
-    // Remove blocks
-    for block in blocksToRemove {
-      allBlocks[block.uuid] = nil
+    // Fire listeners for all blocks that were removed
+    for block in removedBlocks {
+      listeners.forEach { $0.workspace(self, didRemoveBlock: block) }
     }
   }
 

--- a/Source/UI/View Controllers/WorkbenchViewController.swift
+++ b/Source/UI/View Controllers/WorkbenchViewController.swift
@@ -1090,8 +1090,11 @@ extension WorkbenchViewController {
 
     // Check current parent of block
     if let inferiorConnection = block.inferiorConnection {
-      if let currentParent = inferiorConnection.targetBlock, currentParent.uuid == parentID {
-        // No-op: The block is already connected to the parent it should be connected to.
+      if let currentParent = inferiorConnection.targetBlock,
+        currentParent.uuid == parentID,
+        inferiorConnection.targetConnection?.sourceInput?.name == inputName
+      {
+        // No-op: The block is already connected to the target connection.
         return
       } else {
         do {
@@ -1184,8 +1187,10 @@ extension WorkbenchViewController {
       case .mutate:
         do {
           // Update the mutator from xml
+          let mutatorLayout = block.mutator?.layout
           let xml = try AEXMLDocument(xml: value)
-          try block.mutator?.layout?.performMutation(fromXML: xml)
+          mutatorLayout?.beginMutationSession()
+          try mutatorLayout?.performMutation(fromXML: xml)
         } catch let error {
           bky_assertionFailure("Can't update mutator from xml [\"\(value)\"]:\n\(error)")
         }
@@ -1510,6 +1515,10 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
     // on-going drags when the screen is rotated).
 
     if touchState == .began {
+      if EventManager.sharedInstance.groupID == nil {
+        EventManager.sharedInstance.startGroup()
+      }
+
       let inToolbox = gesture.view == toolboxCategoryViewController.view
       let inTrash = gesture.view == _trashCanViewController.view
       // If the touch is in the toolbox, copy the block over to the workspace first.
@@ -1588,6 +1597,7 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
           removeUIStateValue(.trashCanHighlighted)
         }
 
+        EventManager.sharedInstance.stopGroup()
         EventManager.sharedInstance.firePendingEvents()
       }
     }

--- a/Source/UI/View Controllers/WorkbenchViewController.swift
+++ b/Source/UI/View Controllers/WorkbenchViewController.swift
@@ -1189,7 +1189,6 @@ extension WorkbenchViewController {
           // Update the mutator from xml
           let mutatorLayout = block.mutator?.layout
           let xml = try AEXMLDocument(xml: value)
-          mutatorLayout?.beginMutationSession()
           try mutatorLayout?.performMutation(fromXML: xml)
         } catch let error {
           bky_assertionFailure("Can't update mutator from xml [\"\(value)\"]:\n\(error)")

--- a/Source/UI/View Controllers/WorkspaceViewController.swift
+++ b/Source/UI/View Controllers/WorkspaceViewController.swift
@@ -60,7 +60,8 @@ public protocol WorkspaceViewControllerDelegate {
   /**
    Called when the `WorkspaceViewController` was dismissed.
 
-   - parameter workspaceViewController: The `WorkspaceViewController` that was dismissed.
+   - parameter workspaceViewController: The `WorkspaceViewController` that dismissed a view
+   controller.
    */
   func workspaceViewControllerDismissedViewController(
     _ workspaceViewController: WorkspaceViewController)
@@ -221,7 +222,19 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
   public func layoutView(_ layoutView: LayoutView,
     requestedToPresentViewController viewController: UIViewController)
   {
+    delegate?.workspaceViewController(self, willPresentViewController: viewController)
+
     present(viewController, animated: true, completion: nil)
+  }
+
+  public func layoutView(_ layoutView: LayoutView,
+                         requestedToDismissPopoverViewController viewController: UIViewController,
+                         animated: Bool) {
+    viewController.presentingViewController?.dismiss(animated: animated, completion: nil)
+
+    // Manually fire our custom delegate since it doesn't automatically get triggered from
+    // `self.popoverPresentationControllerDidDismissPopover(:)`.
+    self.delegate?.workspaceViewControllerDismissedViewController(self)
   }
 }
 

--- a/Source/UI/Views/FieldAngleView.swift
+++ b/Source/UI/Views/FieldAngleView.swift
@@ -135,11 +135,13 @@ extension FieldAngleView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    // Only commit the change after the user has finished editing the field
-    fieldAngleLayout?.updateAngle(fromText: (textField.text ?? ""))
+    EventManager.sharedInstance.groupAndFireEvents {
+      // Only commit the change after the user has finished editing the field
+      fieldAngleLayout?.updateAngle(fromText: (textField.text ?? ""))
 
-    // Update the text from the layout
-    updateTextFieldFromLayout()
+      // Update the text from the layout
+      updateTextFieldFromLayout()
+    }
   }
 
   public func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Source/UI/Views/FieldCheckboxView.swift
+++ b/Source/UI/Views/FieldCheckboxView.swift
@@ -98,7 +98,9 @@ open class FieldCheckboxView: FieldView {
   // MARK: - Private
 
   fileprivate dynamic func switchValueDidChange(_ sender: UISwitch) {
-    fieldCheckboxLayout?.updateCheckbox(switchButton.isOn)
+    EventManager.sharedInstance.groupAndFireEvents {
+      fieldCheckboxLayout?.updateCheckbox(switchButton.isOn)
+    }
   }
 }
 

--- a/Source/UI/Views/FieldColorView.swift
+++ b/Source/UI/Views/FieldColorView.swift
@@ -116,7 +116,10 @@ extension FieldColorView: FieldColorPickerViewControllerDelegate {
   public func fieldColorPickerViewController(
     _ viewController: FieldColorPickerViewController, didPickColor color: UIColor)
   {
-    fieldColorLayout?.updateColor(color)
-    viewController.presentingViewController?.dismiss(animated: true, completion: nil)
+    EventManager.sharedInstance.groupAndFireEvents {
+      fieldColorLayout?.updateColor(color)
+      popoverDelegate?.layoutView(
+        self, requestedToDismissPopoverViewController: viewController, animated: true)
+    }
   }
 }

--- a/Source/UI/Views/FieldDateView.swift
+++ b/Source/UI/Views/FieldDateView.swift
@@ -124,7 +124,9 @@ open class FieldDateView: FieldView {
   }
 
   fileprivate func updateDateFromDatePicker() {
-    fieldDateLayout?.updateDate(datePicker.date)
+    EventManager.sharedInstance.groupAndFireEvents {
+      fieldDateLayout?.updateDate(datePicker.date)
+    }
   }
 }
 

--- a/Source/UI/Views/FieldDropdownView.swift
+++ b/Source/UI/Views/FieldDropdownView.swift
@@ -144,7 +144,10 @@ extension FieldDropdownView: DropdownOptionsViewControllerDelegate {
   public func dropdownOptionsViewController(_ viewController: DropdownOptionsViewController,
     didSelectOptionIndex optionIndex: Int)
   {
-    fieldDropdownLayout?.updateSelectedIndex(optionIndex)
-    viewController.presentingViewController?.dismiss(animated: true, completion: nil)
+    EventManager.sharedInstance.groupAndFireEvents {
+      fieldDropdownLayout?.updateSelectedIndex(optionIndex)
+      popoverDelegate?.layoutView(
+        self, requestedToDismissPopoverViewController: viewController, animated: true)
+    }
   }
 }

--- a/Source/UI/Views/FieldInputView.swift
+++ b/Source/UI/Views/FieldInputView.swift
@@ -112,8 +112,10 @@ extension FieldInputView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    // Only commit the change after the user has finished editing the field
-    fieldInputLayout?.updateText(self.textField.text ?? "")
+    EventManager.sharedInstance.groupAndFireEvents {
+      // Only commit the change after the user has finished editing the field
+      fieldInputLayout?.updateText(self.textField.text ?? "")
+    }
   }
 }
 

--- a/Source/UI/Views/FieldNumberView.swift
+++ b/Source/UI/Views/FieldNumberView.swift
@@ -144,11 +144,13 @@ extension FieldNumberView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    // Only commit the change after the user has finished editing the field
-    fieldNumberLayout?.setValueFromLocalizedText(self.textField.text ?? "")
+    EventManager.sharedInstance.groupAndFireEvents {
+      // Only commit the change after the user has finished editing the field
+      fieldNumberLayout?.setValueFromLocalizedText(self.textField.text ?? "")
 
-    // Update the text field based on the current fieldNumber
-    updateTextFieldFromFieldNumber()
+      // Update the text field based on the current fieldNumber
+      updateTextFieldFromFieldNumber()
+    }
   }
 
   public func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Source/UI/Views/FieldVariableView.swift
+++ b/Source/UI/Views/FieldVariableView.swift
@@ -155,7 +155,8 @@ extension FieldVariableView: DropdownOptionsViewControllerDelegate {
 
     let options = fieldVariableLayout.variables
     let value = viewController.options[optionIndex].value
-    viewController.presentingViewController?.dismiss(animated: true, completion: nil)
+    popoverDelegate?.layoutView(
+      self, requestedToDismissPopoverViewController: viewController, animated: false)
     if (optionIndex == options.count) {
       // Pop up a dialog to rename the variable.
       renameVariable(fieldVariableLayout: fieldVariableLayout)
@@ -164,7 +165,9 @@ extension FieldVariableView: DropdownOptionsViewControllerDelegate {
       removeVariable(fieldVariableLayout: fieldVariableLayout)
     } else {
       // Change to a new variable
-      fieldVariableLayout.changeToExistingVariable(value)
+      EventManager.sharedInstance.groupAndFireEvents {
+        fieldVariableLayout.changeToExistingVariable(value)
+      }
     }
   }
 
@@ -189,7 +192,9 @@ extension FieldVariableView: DropdownOptionsViewControllerDelegate {
         return
       }
 
-      fieldVariableLayout.renameVariable(to: newName)
+      EventManager.sharedInstance.groupAndFireEvents {
+        fieldVariableLayout.renameVariable(to: newName)
+      }
     }
     renameView.addAction(renameAlertAction)
 
@@ -205,8 +210,10 @@ extension FieldVariableView: DropdownOptionsViewControllerDelegate {
   private func removeVariable(fieldVariableLayout: FieldVariableLayout) {
     let variableCount = fieldVariableLayout.numberOfVariableReferences()
     if variableCount == 1 {
-      // If this is the only instance of this variable, remove it.
-      fieldVariableLayout.removeVariable()
+      EventManager.sharedInstance.groupAndFireEvents {
+        // If this is the only instance of this variable, remove it.
+        fieldVariableLayout.removeVariable()
+      }
     } else {
       // Otherwise, verify the user intended to remove all instances of this variable.
       let removeView = UIAlertController(title:
@@ -214,7 +221,9 @@ extension FieldVariableView: DropdownOptionsViewControllerDelegate {
         message: "", preferredStyle: .alert)
       removeView.addAction(UIAlertAction(title: "Cancel", style: .default, handler: nil))
       removeView.addAction(UIAlertAction(title: "Remove", style: .default) { _ in
-        fieldVariableLayout.removeVariable()
+        EventManager.sharedInstance.groupAndFireEvents {
+          fieldVariableLayout.removeVariable()
+        }
       })
 
       popoverDelegate?.layoutView(self, requestedToPresentViewController: removeView)

--- a/Source/UI/Views/LayoutView.swift
+++ b/Source/UI/Views/LayoutView.swift
@@ -42,6 +42,17 @@ public protocol LayoutPopoverDelegate {
   func layoutView(_ layoutView: LayoutView,
                  requestedToPresentPopoverViewController viewController: UIViewController,
                  fromView: UIView) -> Bool
+
+  /**
+   Event is called when a layout view requests to dismiss a view controller.
+
+   - parameter layoutView: The `LayoutView` that made the request.
+   - parameter viewController: The `UIViewController` to dismiss.
+   - parameter animated: Pass `true` to animate the transition.
+   */
+  func layoutView(_ layoutView: LayoutView,
+                  requestedToDismissPopoverViewController viewController: UIViewController,
+                  animated: Bool)
 }
 
 /**

--- a/Source/UI/Views/MutatorIfElseView.swift
+++ b/Source/UI/Views/MutatorIfElseView.swift
@@ -98,8 +98,8 @@ open class MutatorIfElseView: LayoutView {
       MutatorIfElseViewPopoverController(mutatorIfElseLayout: mutatorIfElseLayout)
     viewController.preferredContentSize = CGSize(width: 220, height: 100)
 
-    // Start new mutation session to automatically preserve connections as the block is mutated
-    mutatorIfElseLayout.beginMutationSession()
+    // Preserve the current input connections so that subsequent mutations don't disconnect them
+    mutatorIfElseLayout.preserveCurrentInputConnections()
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,

--- a/Source/UI/Views/MutatorIfElseView.swift
+++ b/Source/UI/Views/MutatorIfElseView.swift
@@ -98,8 +98,8 @@ open class MutatorIfElseView: LayoutView {
       MutatorIfElseViewPopoverController(mutatorIfElseLayout: mutatorIfElseLayout)
     viewController.preferredContentSize = CGSize(width: 220, height: 100)
 
-    // Preserve the current input connections so that subsequent mutations don't disconnect them
-    mutatorIfElseLayout.preserveCurrentInputConnections()
+    // Start new mutation session to automatically preserve connections as the block is mutated
+    mutatorIfElseLayout.beginMutationSession()
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,
@@ -177,6 +177,18 @@ fileprivate class MutatorIfElseViewPopoverController: UITableViewController {
     }
   }
 
+  // MARK: - Perform Mutation
+
+  fileprivate func performMutation() {
+    do {
+      try EventManager.sharedInstance.groupAndFireEvents {
+        try mutatorIfElseLayout.performMutation()
+      }
+    } catch let error {
+      bky_assertionFailure("Could not update if/else block: \(error)")
+    }
+  }
+
   // MARK: - Else Mutation
 
   fileprivate dynamic func updateElseCount() {
@@ -184,7 +196,7 @@ fileprivate class MutatorIfElseViewPopoverController: UITableViewController {
       let accessoryView = cell.accessoryView as? UISwitch
     {
       mutatorIfElseLayout.elseStatement = accessoryView.isOn
-      try? mutatorIfElseLayout.performMutation()
+      performMutation()
     }
   }
 }
@@ -196,6 +208,6 @@ extension MutatorIfElseViewPopoverController: IntegerIncrementerViewDelegate {
     _ integerIncrementerView: IntegerIncrementerView, didChangeToValue value: Int)
   {
     mutatorIfElseLayout.elseIfCount = value
-    try? mutatorIfElseLayout.performMutation()
+    performMutation()
   }
 }

--- a/Source/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Source/UI/Views/MutatorProcedureDefinitionView.swift
@@ -96,8 +96,8 @@ open class MutatorProcedureDefinitionView: LayoutView {
 
     let viewController = MutatorProcedureDefinitionPopoverController(mutatorLayout: mutatorLayout)
 
-    // Start new mutation session to automatically preserve connections as the block is mutated
-    mutatorLayout.beginMutationSession()
+    // Preserve the current input connections so that subsequent mutations don't disconnect them
+    mutatorLayout.preserveCurrentInputConnections()
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,

--- a/Source/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Source/UI/Views/MutatorProcedureDefinitionView.swift
@@ -96,8 +96,8 @@ open class MutatorProcedureDefinitionView: LayoutView {
 
     let viewController = MutatorProcedureDefinitionPopoverController(mutatorLayout: mutatorLayout)
 
-    // Preserve the current input connections so that subsequent mutations don't disconnect them
-    mutatorLayout.preserveCurrentInputConnections()
+    // Start new mutation session to automatically preserve connections as the block is mutated
+    mutatorLayout.beginMutationSession()
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,
@@ -410,7 +410,9 @@ fileprivate class MutatorProcedureDefinitionPopoverController: UITableViewContro
 
   func performMutation() {
     do {
-      try mutatorLayout.performMutation()
+      try EventManager.sharedInstance.groupAndFireEvents {
+        try mutatorLayout.performMutation()
+      }
     } catch let error {
       bky_assertionFailure("Could not perform mutation: \(error)")
     }


### PR DESCRIPTION
- Added BlockMoveEvent to simplify tracking an individual Block's movement changes
- Changed Workspace listener from willRemoveBlock: to didRemoveBlock:, as listeners needed the latter, not the former
- Changed behavior so calls to fire (and group) pending events are done at the View layer, not the Layout layer
- Added method to MutatorLayout to indicate when starting a mutator 'session'. This is needed when replaying events as old mutators were storing stale data from previous unrelated sessions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/329)
<!-- Reviewable:end -->
