### PR TITLE
- Added willAddBlock to WorkspaceListener

### DIFF
--- a/Source/Control/EventManager.swift
+++ b/Source/Control/EventManager.swift
@@ -50,13 +50,13 @@ public final class EventManager: NSObject {
   public var isEnabled: Bool = true
 
   /// The current group ID that is automatically assigned to new events with no group ID.
-  public private(set) var groupID: String?
+  public private(set) var currentGroupID: String?
 
   /// The stack of group IDs that have been created thus far.
   private var _groupStack = [String]() {
     didSet {
       // Update the current group ID
-      groupID = _groupStack.last
+      currentGroupID = _groupStack.last
     }
   }
 
@@ -87,7 +87,7 @@ public final class EventManager: NSObject {
     }
 
     if event.groupID == nil {
-      event.groupID = groupID
+      event.groupID = currentGroupID
     }
 
     pendingEvents.append(event)

--- a/Source/Control/EventManager.swift
+++ b/Source/Control/EventManager.swift
@@ -155,7 +155,8 @@ public final class EventManager: NSObject {
 
    - parameter groupID: The groupID to push.
    - note: It is not recommended to push a group ID that differs from `self.currentGroupID`,
-   if it is not `nil`. Doing this will result in an error in debug mode and a warning in release mode.
+   if it is not `nil`. Doing this will result in an error in debug mode and a warning in release
+   mode.
    */
   public func pushGroup(groupID: String) {
     if let currentGroupID = self.currentGroupID, currentGroupID != groupID {

--- a/Source/Control/ProcedureCoordinator.swift
+++ b/Source/Control/ProcedureCoordinator.swift
@@ -409,6 +409,8 @@ extension ProcedureCoordinator: WorkspaceListener {
 extension ProcedureCoordinator: EventManagerListener {
 
   public func eventManager(_ eventManager: EventManager, didFireEvent event: BlocklyEvent) {
+    // Try to handle the event. The first method that returns `true` means it's been handled and
+    // we can skip the rest of the checks.
     if checkProcedureDefinitionNameChangeEvent(event) {
     } else if checkProcedureDefinitionMutationEvent(event) {
     }

--- a/Source/Layout/FieldLayout.swift
+++ b/Source/Layout/FieldLayout.swift
@@ -93,7 +93,9 @@ open class FieldLayout: Layout {
    native value.
    */
   public func setValue(fromSerializedText text: String) throws {
-    try field.setValueFromSerializedText(text)
+    try captureChangeEvent {
+      try field.setValueFromSerializedText(text)
+    }
   }
 
   // MARK: - Change Events
@@ -105,13 +107,13 @@ open class FieldLayout: Layout {
 
    - parameter closure: A closure to execute, that will change the state of `self.field`.
    */
-  open func captureChangeEvent(_ closure: () -> Void) {
+  open func captureChangeEvent(_ closure: () throws -> Void) rethrows {
     if let workspace = firstAncestor(ofType: WorkspaceLayout.self)?.workspace,
       let block = field.sourceInput?.sourceBlock
     {
       // Capture values before and after running update
       let oldValue = try? field.serializedText()
-      closure()
+      try closure()
       let newValue = try? field.serializedText()
 
       if case let anOldValue?? = oldValue,
@@ -125,7 +127,7 @@ open class FieldLayout: Layout {
       }
     } else {
       // Just run update
-      closure()
+      try closure()
     }
   }
 }

--- a/Source/Layout/FieldVariableLayout.swift
+++ b/Source/Layout/FieldVariableLayout.swift
@@ -65,6 +65,8 @@ open class FieldVariableLayout: FieldLayout {
     }
   }
 
+  // TODO:(#334) Investigate decoupling FieldVariableLayout from WorkspaceLayoutCoordinator.
+
   // Used to determine information about the variables on the workspace. Only set if the variable
   // layout is on a workspace.
   internal weak var layoutCoordinator: WorkspaceLayoutCoordinator?

--- a/Source/Layout/MutatorIfElseLayout.swift
+++ b/Source/Layout/MutatorIfElseLayout.swift
@@ -74,19 +74,14 @@ public class MutatorIfElseLayout : MutatorLayout {
     // Update the definition of the block
     try captureChangeEvent {
       try mutatorIfElse.mutateBlock()
-    }
 
-    // Update UI
-    let blockLayout = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      // Update UI
+      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+    }
 
     // Reconnect saved connections
     try mutatorHelper.reconnectSavedTargetConnections(
       toInputs: mutatorIfElse.sortedMutatorInputs(), layoutCoordinator: layoutCoordinator)
-
-    Layout.animate {
-      layoutCoordinator.blockBumper
-        .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
-    }
   }
 
   public override func performMutation(fromXML xml: AEXMLElement) throws {

--- a/Source/Layout/MutatorIfElseLayout.swift
+++ b/Source/Layout/MutatorIfElseLayout.swift
@@ -76,7 +76,7 @@ public class MutatorIfElseLayout : MutatorLayout {
       try mutatorIfElse.mutateBlock()
 
       // Update UI
-      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      try layoutCoordinator.rebuildLayoutTree(forBlock: block)
     }
 
     // Reconnect saved connections

--- a/Source/Layout/MutatorProcedureCallerLayout.swift
+++ b/Source/Layout/MutatorProcedureCallerLayout.swift
@@ -79,18 +79,13 @@ public class MutatorProcedureCallerLayout : MutatorLayout {
     // Update the definition of the block
     try captureChangeEvent {
       try mutatorProcedureCaller.mutateBlock()
-    }
 
-    // Update UI
-    let blockLayout = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      // Update UI
+      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+    }
 
     // Reconnect saved connections
     try reconnectSavedTargetConnections()
-
-    Layout.animate {
-      layoutCoordinator.blockBumper
-        .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
-    }
   }
 
   public override func performMutation(fromXML xml: AEXMLElement) throws {

--- a/Source/Layout/MutatorProcedureCallerLayout.swift
+++ b/Source/Layout/MutatorProcedureCallerLayout.swift
@@ -81,7 +81,7 @@ public class MutatorProcedureCallerLayout : MutatorLayout {
       try mutatorProcedureCaller.mutateBlock()
 
       // Update UI
-      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      try layoutCoordinator.rebuildLayoutTree(forBlock: block)
     }
 
     // Reconnect saved connections

--- a/Source/Layout/MutatorProcedureDefinitionLayout.swift
+++ b/Source/Layout/MutatorProcedureDefinitionLayout.swift
@@ -84,25 +84,15 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
     // Update the definition of the block
     try captureChangeEvent {
       try mutatorProcedureDefinition.mutateBlock()
-    }
 
-    // Update UI
-    let blockLayout = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      // Update UI
+      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+    }
 
     // Reconnect saved connections
     try mutatorHelper.reconnectSavedTargetConnections(
       toInputs: mutatorProcedureDefinition.sortedMutatorInputs(),
       layoutCoordinator: layoutCoordinator)
-
-    Layout.animate {
-      layoutCoordinator.blockBumper
-        .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
-    }
-
-    // Post notification that this layout finished mutating
-    NotificationCenter.default.post(
-      name: MutatorProcedureDefinitionLayout.NotificationDidPerformMutation,
-      object: self)
   }
 
   public override func performMutation(fromXML xml: AEXMLElement) throws {

--- a/Source/Layout/MutatorProcedureDefinitionLayout.swift
+++ b/Source/Layout/MutatorProcedureDefinitionLayout.swift
@@ -86,7 +86,7 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
       try mutatorProcedureDefinition.mutateBlock()
 
       // Update UI
-      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      try layoutCoordinator.rebuildLayoutTree(forBlock: block)
     }
 
     // Reconnect saved connections

--- a/Source/Layout/MutatorProcedureIfReturnLayout.swift
+++ b/Source/Layout/MutatorProcedureIfReturnLayout.swift
@@ -79,7 +79,7 @@ public class MutatorProcedureIfReturnLayout : MutatorLayout {
       try mutatorProcedureIfReturn.mutateBlock()
 
       // Update UI
-      _ = try layoutCoordinator.rebuildLayoutTree(forBlock: block)
+      try layoutCoordinator.rebuildLayoutTree(forBlock: block)
     }
 
     // Reconnect saved connections

--- a/Source/Layout/WorkspaceLayoutCoordinator.swift
+++ b/Source/Layout/WorkspaceLayoutCoordinator.swift
@@ -332,7 +332,7 @@ open class WorkspaceLayoutCoordinator: NSObject {
    - throws:
    `BlocklyError`: Thrown if the specified block is not associated with a layout yet.
    */
-  open func rebuildLayoutTree(forBlock block: Block) throws -> BlockLayout {
+  open func rebuildLayoutTree(forBlock block: Block) throws {
     guard block.layout != nil else {
       throw BlocklyError(.illegalState,
         "Cannot re-build layout tree for a block that's not already associated with a layout.")
@@ -352,8 +352,6 @@ open class WorkspaceLayoutCoordinator: NSObject {
     // Update the layout tree, in both directions
     blockLayout.updateLayoutDownTree()
     blockLayout.updateLayoutUpTree()
-
-    return blockLayout
   }
 
   // MARK: - Private

--- a/Source/Layout/WorkspaceLayoutCoordinator.swift
+++ b/Source/Layout/WorkspaceLayoutCoordinator.swift
@@ -24,16 +24,6 @@ import Foundation
 open class WorkspaceLayoutCoordinator: NSObject {
   // MARK: - Properties
 
-  /**
-   Notification that is fired after this layout has connected two connections together.
-
-   The notification's `userInfo` will contain a dictionary of the form:
-
-   `{ "connections": [<Connection>, <Connection>] }`
-   */
-  public static let NotificationDidConnect =
-    Notification.Name("WorkspaceLayoutCoordinatorNotificationDidConnect")
-
   /// The workspace layout whose layout hierarchy is being managed by this object
   open let workspaceLayout: WorkspaceLayout
 
@@ -268,11 +258,11 @@ open class WorkspaceLayoutCoordinator: NSObject {
 
     connection.disconnect()
 
-    event.recordNewValues()
-    EventManager.sharedInstance.addPendingEvent(event)
-
     self.didChangeTarget(forConnection: connection, oldTarget: oldTarget)
     self.didChangeTarget(forConnection: oldTarget, oldTarget: connection)
+
+    event.recordNewValues()
+    EventManager.sharedInstance.addPendingEvent(event)
   }
 
   /**
@@ -333,15 +323,6 @@ open class WorkspaceLayoutCoordinator: NSObject {
 
     event.recordNewValues()
     EventManager.sharedInstance.addPendingEvent(event)
-
-    // TODO:(#272) When events are implemented, re-visit whether these notifications should be
-    // posted here.
-
-    // Post notification that two connections did connect
-    NotificationCenter.default.post(
-      name: WorkspaceLayoutCoordinator.NotificationDidConnect,
-      object: self,
-      userInfo: ["connections": [connection1, connection2]])
   }
 
   /**

--- a/Source/Model/Event/BlocklyEvent.swift
+++ b/Source/Model/Event/BlocklyEvent.swift
@@ -172,6 +172,8 @@ extension Array where Element: BlocklyEvent {
    `merged(withNextChronologicalEvent:)` on adjacent events.
 
    - returns: An array of merged events.
+   - note: This method assumes that the array is sorted in chronological
+   order.
    */
   public func merged() -> [BlocklyEvent] {
     var mergedEvents = self

--- a/Source/Model/Workspace.swift
+++ b/Source/Model/Workspace.swift
@@ -21,6 +21,14 @@ import Foundation
 @objc(BKYWorkspaceListener)
 public protocol WorkspaceListener: class {
   /**
+   Event that is called when a block will be added to a workspace.
+
+   - parameter workspace: The workspace that will add a block.
+   - parameter block: The block that will be added.
+   */
+  @objc optional func workspace(_ workspace: Workspace, willAddBlock block: Block)
+
+  /**
    Event that is called when a block has been added to a workspace.
 
    - parameter workspace: The workspace that added a block.
@@ -174,6 +182,11 @@ open class Workspace : NSObject {
     if let maxBlocks = self.maxBlocks , (allBlocks.count + newBlocks.count) > maxBlocks {
       throw BlocklyError(.workspaceExceedsCapacity,
         "Adding more blocks would exceed the maximum amount allowed (\(maxBlocks))")
+    }
+
+    // Fire listeners for all blocks that will be added to the workspace
+    for block in newBlocks {
+      listeners.forEach { $0.workspace?(self, willAddBlock: block) }
     }
 
     // All checks passed. Add the new blocks to the workspace.

--- a/Source/UI/View Controllers/WorkbenchViewController.swift
+++ b/Source/UI/View Controllers/WorkbenchViewController.swift
@@ -1512,7 +1512,7 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
     // on-going drags when the screen is rotated).
 
     if touchState == .began {
-      if EventManager.sharedInstance.groupID == nil {
+      if EventManager.sharedInstance.currentGroupID == nil {
         EventManager.sharedInstance.pushNewGroup()
       }
 

--- a/Source/UI/View Controllers/WorkbenchViewController.swift
+++ b/Source/UI/View Controllers/WorkbenchViewController.swift
@@ -883,7 +883,18 @@ extension WorkbenchViewController: EventManagerListener {
     }
 
     if event.workspaceID == workspace?.uuid {
-      _undoStack.append(event)
+      // Try to merge this event with the last one in the undo stack
+      if let lastEvent = _undoStack.last,
+        let mergedEvent = lastEvent.merged(withNextChronologicalEvent: event) {
+        _undoStack.removeLast()
+
+        if !mergedEvent.isDiscardable() {
+          _undoStack.append(mergedEvent)
+        }
+      } else {
+        // Couldn't merge event with last one, just append it
+        _undoStack.append(event)
+      }
 
       // Clear the redo stack now since a new event has been added to the undo stack
       _redoStack.removeAll()
@@ -915,13 +926,7 @@ extension WorkbenchViewController {
       return
     }
 
-    // TODO:(#272) Disabling events here avoids echoing for the library code, but it may prevent
-    // behavior for clients that rely on automatically state based on events being re-fired. We
-    // need to figure out a consistent behavior here.
-
     // Don't listen to any events, to avoid echoing
-    EventManager.sharedInstance.isEnabled = false
-
     _recordEvents = false
 
     // Pop off the next group of events from the undo stack. These events will already be sorted
@@ -941,7 +946,6 @@ extension WorkbenchViewController {
     EventManager.sharedInstance.firePendingEvents()
 
     // Listen to events again
-    EventManager.sharedInstance.isEnabled = true
     _recordEvents = true
   }
 
@@ -950,12 +954,7 @@ extension WorkbenchViewController {
       return
     }
 
-    // TODO:(#272) Disabling events here avoids echoing for the library code, but it may prevent
-    // behavior for clients that rely on automatically state based on events being re-fired. We
-    // need to figure out a consistent behavior here.
-
     // Don't listen to any events, to avoid echoing
-    EventManager.sharedInstance.isEnabled = false
     _recordEvents = false
 
     // Pop off the next group of events from the redo stack. These events will already be sorted
@@ -975,7 +974,6 @@ extension WorkbenchViewController {
     EventManager.sharedInstance.firePendingEvents()
 
     // Listen to events again
-    EventManager.sharedInstance.isEnabled = true
     _recordEvents = true
   }
 }
@@ -1515,7 +1513,7 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
 
     if touchState == .began {
       if EventManager.sharedInstance.groupID == nil {
-        EventManager.sharedInstance.startGroup()
+        EventManager.sharedInstance.pushNewGroup()
       }
 
       let inToolbox = gesture.view == toolboxCategoryViewController.view
@@ -1596,9 +1594,12 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
           removeUIStateValue(.trashCanHighlighted)
         }
 
-        EventManager.sharedInstance.stopGroup()
-        EventManager.sharedInstance.firePendingEvents()
+        EventManager.sharedInstance.popGroup()
       }
+
+      // Always fire pending events after a finger has been lifted. All grouped events will
+      // eventually get grouped together regardless if they were fired in batches.
+      EventManager.sharedInstance.firePendingEvents()
     }
   }
 }

--- a/Source/UI/Views/MutatorIfElseView.swift
+++ b/Source/UI/Views/MutatorIfElseView.swift
@@ -183,6 +183,13 @@ fileprivate class MutatorIfElseViewPopoverController: UITableViewController {
     do {
       try EventManager.sharedInstance.groupAndFireEvents {
         try mutatorIfElseLayout.performMutation()
+
+        if let blockLayout = mutatorIfElseLayout.mutator.block?.layout {
+          Layout.animate {
+            mutatorIfElseLayout.layoutCoordinator?.blockBumper
+              .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
+          }
+        }
       }
     } catch let error {
       bky_assertionFailure("Could not update if/else block: \(error)")

--- a/Source/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Source/UI/Views/MutatorProcedureDefinitionView.swift
@@ -412,6 +412,13 @@ fileprivate class MutatorProcedureDefinitionPopoverController: UITableViewContro
     do {
       try EventManager.sharedInstance.groupAndFireEvents {
         try mutatorLayout.performMutation()
+
+        if let blockLayout = mutatorLayout.mutator.block?.layout {
+          Layout.animate {
+            mutatorLayout.layoutCoordinator?.blockBumper
+              .bumpNeighbors(ofBlockLayout: blockLayout, alwaysBumpOthers: true)
+          }
+        }
       }
     } catch let error {
       bky_assertionFailure("Could not perform mutation: \(error)")


### PR DESCRIPTION
- Updated ProcedureCoordinator to always create definition blocks before the caller blocks, if it doesn't exist
- Changed mutator layouts so they don't automatically perform block bumping after mutations. Callers performing the mutations are now responsible for block bumping.
- Updated FieldLayout to capture change event when setting value from serialized text
- Changed EventManager grouping so it operates as a stack of group events
- Replaced use of NSNotifications with EventManager. Workbench also now fires events when replaying event stack (it previously disabled events)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/333)
<!-- Reviewable:end -->
