### PR TITLE
Versioning off to 0.7.4 (#371)

### DIFF
--- a/Blockly.podspec
+++ b/Blockly.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Blockly'
   s.module_name      = 'Blockly'
-  s.version          = '0.7.3'
+  s.version          = '0.7.4'
   s.summary          = 'A library from Google for building visual programming editors.'
   s.description      = <<-DESC
   Blockly is a visual editor that allows users to write programs by plugging blocks together.
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
     'Resources/Localized/**/*.lproj/*']
 
   s.frameworks        = 'WebKit'
-  s.ios.dependency 'AEXML', '~> 4.0.1'
+  s.ios.dependency 'AEXML', '~> 4.1.0'
 
   s.pod_target_xcconfig = {
       # Enable whole-module-optimization for all builds except for Debug builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [Version 0.7.4](https://github.com/google/blockly-ios/tree/0.7.4) (Apr 2017)
+
+- Updates Cocoapods podspec file to specify AEXML 4.1.0 to accomodate Swift 3.1.
+
 # [Version 0.7.3](https://github.com/google/blockly-ios/tree/0.7.3) (Apr 2017)
 
 - For both `CodeGeneratorService#generateCode(forWorkspace:onCompletion:onError:)` and

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "tadija/AEXML" "4.0.1"
+github "tadija/AEXML" "4.1.0"

--- a/Samples/BlocklySample/Info.plist
+++ b/Samples/BlocklySample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.3</string>
+	<string>0.7.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.3</string>
+	<string>0.7.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
* Upping the AEXML dependency, so we use the Swift 3.1-compatible version.

* Versioning off to 0.7.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/372)
<!-- Reviewable:end -->
