### PR TITLE
Cherry-picking a change from develop to fix tests on master.

### DIFF
--- a/Sources/Control/ProcedureCoordinator.swift
+++ b/Sources/Control/ProcedureCoordinator.swift
@@ -112,7 +112,7 @@ public class ProcedureCoordinator: NSObject {
         if block.isProcedureDefinition {
           trackProcedureDefinitionBlock(block)
         } else if block.isProcedureCaller {
-          trackProcedureCallerBlock(block, autoCreateDefinition: false)
+          trackProcedureCallerBlock(block)
         }
       }
 
@@ -258,16 +258,24 @@ public class ProcedureCoordinator: NSObject {
   }
 
   fileprivate func procedureDefinitionBlock(forCallerBlock callerBlock: Block) -> Block? {
-    return definitionBlocks.first(where: {
-      $0.associatedCallerBlockName == callerBlock.name &&
-      procedureNameManager.namesAreEqual(callerBlock.procedureName, $0.procedureName) &&
-      callerBlock.procedureParameters.map({ $0.name }) == $0.procedureParameters.map({ $0.name })
-    })
+    return definitionBlocks.first(where: { definitionBlock($0, matchesCallerBlock: callerBlock) })
+  }
+
+  fileprivate func definitionBlock(
+    _ definitionBlock: Block, matchesCallerBlock callerBlock: Block) -> Bool {
+    return
+      definitionBlock.isProcedureDefinition &&
+      callerBlock.isProcedureCaller &&
+      definitionBlock.associatedCallerBlockName == callerBlock.name &&
+      procedureNameManager.namesAreEqual(
+        definitionBlock.procedureName, callerBlock.procedureName) &&
+      definitionBlock.procedureParameters.map({ $0.name }) ==
+        callerBlock.procedureParameters.map({ $0.name })
   }
 
   // MARK: - Procedure Caller Methods
 
-  fileprivate func trackProcedureCallerBlock(_ callerBlock: Block, autoCreateDefinition: Bool) {
+  fileprivate func trackProcedureCallerBlock(_ callerBlock: Block) {
     guard callerBlock.isProcedureCaller else {
       return
     }
@@ -279,9 +287,6 @@ public class ProcedureCoordinator: NSObject {
       // Make sure the procedure caller block has the exact same parameters as the definition block,
       // so its parameters' connections are properly preserved on parameter renames/re-orderings
       callerBlock.procedureParameters = definitionBlock.procedureParameters
-    } else if autoCreateDefinition {
-      // Create definition block
-      createProcedureDefinitionBlock(fromCallerBlock: callerBlock)
     }
   }
 
@@ -370,38 +375,54 @@ public class ProcedureCoordinator: NSObject {
 extension ProcedureCoordinator: WorkspaceListener {
   // MARK: - WorkspaceListener Implementation
 
-  public func workspace(_ workspace: Workspace, willAddBlock block: Block) {
-    if block.isProcedureCaller && procedureDefinitionBlock(forCallerBlock: block) == nil {
-      // No procedure block exists for this caller in the workspace.
-      // Automatically create it first before adding in the caller block to the workspace. This
-      // makes sure that events are ordered in such a way that they can be properly undone.
-      createProcedureDefinitionBlock(fromCallerBlock: block)
+  public func workspace(_ workspace: Workspace, willAddBlockTrees blockTrees: [Block]) {
+    // Look at all block trees that are being added to see if any caller blocks need to have 
+    // definitions auto-created for them.
+    let definitionBlocks = blockTrees.filter({ $0.isProcedureDefinition })
+    let callerBlocks =
+      blockTrees.flatMap({ $0.allBlocksForTree() }).filter({ $0.isProcedureCaller })
+
+    for callerBlock in callerBlocks {
+      if procedureDefinitionBlock(forCallerBlock: callerBlock) == nil &&
+        !definitionBlocks.contains(where: { definitionBlock($0, matchesCallerBlock: callerBlock) })
+      {
+        // No procedure block exists for this caller in the workspace.
+        // Automatically create it first before adding in the caller block to the workspace. This
+        // makes sure that events are ordered in such a way that they can be properly undone.
+        createProcedureDefinitionBlock(fromCallerBlock: callerBlock)
+      }
     }
   }
 
-  public func workspace(_ workspace: Workspace, didAddBlock block: Block) {
-    if block.isProcedureDefinition {
-      trackProcedureDefinitionBlock(block)
-    } else if block.isProcedureCaller {
-      trackProcedureCallerBlock(block, autoCreateDefinition: true)
+  public func workspace(_ workspace: Workspace, didAddBlockTrees blockTrees: [Block]) {
+    for block in blockTrees.flatMap({ $0.allBlocksForTree() }) {
+      if block.isProcedureDefinition {
+        trackProcedureDefinitionBlock(block)
+      } else if block.isProcedureCaller {
+        trackProcedureCallerBlock(block)
+      }
     }
   }
 
-  public func workspace(_ workspace: Workspace, willRemoveBlock block: Block) {
-    if block.isProcedureDefinition {
-      // Remove all caller blocks for the definition before removing the definition block. If
-      // the caller blocks are removed after the definition block, then it causes problems undoing
-      // the event stack where a caller block is recreated without any definition block. Reversing
-      // the order fixes this problem.
-      removeProcedureCallerBlocks(forDefinitionBlock: block)
+  public func workspace(_ workspace: Workspace, willRemoveBlockTrees blockTrees: [Block]) {
+    for block in blockTrees {
+      if block.isProcedureDefinition {
+        // Remove all caller blocks for the definition before removing the definition block. If
+        // the caller blocks are removed after the definition block, then it causes problems undoing
+        // the event stack where a caller block is recreated without any definition block. Reversing
+        // the order fixes this problem.
+        removeProcedureCallerBlocks(forDefinitionBlock: block)
+      }
     }
   }
 
-  public func workspace(_ workspace: Workspace, didRemoveBlock block: Block) {
-    if block.isProcedureDefinition {
-      untrackProcedureDefinitionBlock(block)
-    } else if block.isProcedureCaller {
-      untrackProcedureCallerBlock(block)
+  public func workspace(_ workspace: Workspace, didRemoveBlockTrees blockTrees: [Block]) {
+    for block in blockTrees.flatMap({ $0.allBlocksForTree() }) {
+      if block.isProcedureDefinition {
+        untrackProcedureDefinitionBlock(block)
+      } else if block.isProcedureCaller {
+        untrackProcedureCallerBlock(block)
+      }
     }
   }
 }

--- a/Sources/Layout/WorkspaceLayoutCoordinator.swift
+++ b/Sources/Layout/WorkspaceLayoutCoordinator.swift
@@ -742,62 +742,57 @@ open class WorkspaceLayoutCoordinator: NSObject {
 // MARK: - WorkspaceListener implementation
 
 extension WorkspaceLayoutCoordinator: WorkspaceListener {
-  public func workspace(_ workspace: Workspace, didAddBlock block: Block) {
-    if !block.topLevel {
-      // We only need to create layout trees for top level blocks
-      return
-    }
+  public func workspace(_ workspace: Workspace, didAddBlockTrees blockTrees: [Block]) {
+    for block in blockTrees {
+      do {
+        // Fire creation event for the root block
+        let event = try BlocklyEvent.Create(workspace: workspaceLayout.workspace, block: block)
+        EventManager.sharedInstance.addPendingEvent(event)
 
-    do {
-      // Fire creation event for the root block
-      let event = try BlocklyEvent.Create(workspace: workspaceLayout.workspace, block: block)
-      EventManager.sharedInstance.addPendingEvent(event)
+        // Create the layout tree for this newly added block
+        let blockGroupLayout =
+          try layoutBuilder.buildLayoutTree(forTopLevelBlock: block,
+                                            workspaceLayout: workspaceLayout)
 
-      // Create the layout tree for this newly added block
-      let blockGroupLayout =
-        try layoutBuilder.buildLayoutTree(forTopLevelBlock: block, workspaceLayout: workspaceLayout)
+        // Perform a layout for the tree
+        blockGroupLayout.updateLayoutDownTree()
 
-      // Perform a layout for the tree
-      blockGroupLayout.updateLayoutDownTree()
+        // Track all block layouts
+        for blockLayout in blockGroupLayout.flattenedLayoutTree(ofType: BlockLayout.self) {
+          trackBlockLayout(blockLayout)
+        }
 
-      // Track all block layouts
-      for blockLayout in blockGroupLayout.flattenedLayoutTree(ofType: BlockLayout.self) {
-        trackBlockLayout(blockLayout)
+        // Update the content size
+        workspaceLayout.updateCanvasSize()
+
+        // Schedule change event for an added block layout
+        workspaceLayout.sendChangeEvent(withFlags: WorkspaceLayout.Flag_NeedsDisplay)
+      } catch let error {
+        bky_assertionFailure("Could not create the layout tree for block: \(error)")
       }
-
-      // Update the content size
-      workspaceLayout.updateCanvasSize()
-
-      // Schedule change event for an added block layout
-      workspaceLayout.sendChangeEvent(withFlags: WorkspaceLayout.Flag_NeedsDisplay)
-    } catch let error {
-      bky_assertionFailure("Could not create the layout tree for block: \(error)")
     }
   }
 
-  public func workspace(_ workspace: Workspace, didRemoveBlock block: Block) {
-    if !block.topLevel {
-      // We only need to remove layout trees for top-level blocks
-      return
-    }
-
-    do {
-      // Fire delete event for the root block
-      let event = try BlocklyEvent.Delete(workspace: workspaceLayout.workspace, block: block)
-      EventManager.sharedInstance.addPendingEvent(event)
-    } catch let error {
-      bky_assertionFailure("Could not fire delete event: \(error)")
-    }
-
-    if let blockGroupLayout = block.layout?.parentBlockGroupLayout {
-      // Untrack all block layouts
-      for blockLayout in blockGroupLayout.flattenedLayoutTree(ofType: BlockLayout.self) {
-        untrackBlockLayout(blockLayout)
+  public func workspace(_ workspace: Workspace, didRemoveBlockTrees blockTrees: [Block]) {
+    for block in blockTrees {
+      do {
+        // Fire delete event for the root block
+        let event = try BlocklyEvent.Delete(workspace: workspaceLayout.workspace, block: block)
+        EventManager.sharedInstance.addPendingEvent(event)
+      } catch let error {
+        bky_assertionFailure("Could not fire delete event: \(error)")
       }
 
-      workspaceLayout.removeBlockGroupLayout(blockGroupLayout)
+      if let blockGroupLayout = block.layout?.parentBlockGroupLayout {
+        // Untrack all block layouts
+        for blockLayout in blockGroupLayout.flattenedLayoutTree(ofType: BlockLayout.self) {
+          untrackBlockLayout(blockLayout)
+        }
 
-      workspaceLayout.sendChangeEvent(withFlags: WorkspaceLayout.Flag_NeedsDisplay)
+        workspaceLayout.removeBlockGroupLayout(blockGroupLayout)
+
+        workspaceLayout.sendChangeEvent(withFlags: WorkspaceLayout.Flag_NeedsDisplay)
+      }
     }
   }
 }

--- a/Sources/Model/Workspace.swift
+++ b/Sources/Model/Workspace.swift
@@ -21,36 +21,36 @@ import Foundation
 @objc(BKYWorkspaceListener)
 public protocol WorkspaceListener: class {
   /**
-   Event that is called when a block will be added to a workspace.
+   Event that is called when a list of block trees will be added to a workspace.
 
-   - parameter workspace: The workspace that will add a block.
-   - parameter block: The block that will be added.
+   - parameter workspace: The workspace that will add a list of block trees.
+   - parameter blockTrees: The list of root blocks that will be added.
    */
-  @objc optional func workspace(_ workspace: Workspace, willAddBlock block: Block)
+  @objc optional func workspace(_ workspace: Workspace, willAddBlockTrees blockTrees: [Block])
 
   /**
-   Event that is called when a block has been added to a workspace.
+   Event that is called when a list of block trees have been added to a workspace.
 
-   - parameter workspace: The workspace that added a block.
-   - parameter block: The block that was added.
+   - parameter workspace: The workspace that added a list of block trees.
+   - parameter blockTrees: The list of root blocks that have been added.
   */
-  @objc optional func workspace(_ workspace: Workspace, didAddBlock block: Block)
+  @objc optional func workspace(_ workspace: Workspace, didAddBlockTrees blockTrees: [Block])
 
   /**
-   Event that is called when a block will be removed from a workspace.
+   Event that is called when a list of block trees will be removed from a workspace.
 
-   - parameter workspace: The workspace that will remove a block.
-   - parameter block: The block that will be removed.
+   - parameter workspace: The workspace that will remove a list of block trees.
+   - parameter blockTrees: The list of root blocks that will be removed.
    */
-  @objc optional func workspace(_ workspace: Workspace, willRemoveBlock block: Block)
+  @objc optional func workspace(_ workspace: Workspace, willRemoveBlockTrees blockTrees: [Block])
 
   /**
-   Event that is called when a block has been removed from a workspace.
+   Event that is called when a list of block trees have been removed from a workspace.
 
-   - parameter workspace: The workspace that removed a block.
-   - parameter block: The block that was removed.
+   - parameter workspace: The workspace that removed a list of block trees.
+   - parameter blockTrees: The list of root blocks that have been removed.
    */
-  @objc optional func workspace(_ workspace: Workspace, didRemoveBlock block: Block)
+  @objc optional func workspace(_ workspace: Workspace, didRemoveBlockTrees blockTrees: [Block])
 }
 
 /**
@@ -157,51 +157,71 @@ open class Workspace : NSObject {
    allowed.
    */
   open func addBlockTree(_ rootBlock: Block) throws {
-    var newBlocks = [Block]()
+    try addBlockTrees([rootBlock])
+  }
 
-    // Gather list of all new blocks and perform state checks.
+  /**
+   Adds a list of blocks and all of their connected blocks to the workspace.
 
-    for block in rootBlock.allBlocksForTree() {
-      if let existingBlock = allBlocks[block.uuid] {
-        if existingBlock == block {
-          // The block is already in the workspace
-          continue
-        } else {
+   - parameter rootBlocks: The list of root blocks to add.
+   - throws:
+   `BlocklyError`: Thrown if one of the blocks uses a uuid that is already being used by another
+   block in the workspace or if adding the new list of blocks would exceed the maximum amount
+   allowed.
+   */
+  open func addBlockTrees(_ rootBlocks: [Block]) throws {
+    var newRootBlocks = [String: Block]()
+    var newBlocks = [String: Block]()
+
+    // Check that all new blocks will not mess up the state of the workspace.
+    for rootBlock in rootBlocks {
+      if containsBlock(rootBlock) {
+        // This root block is already in the workspace. Skip it.
+        continue
+      } else if !rootBlock.topLevel {
+        throw BlocklyError(.illegalArgument,
+          "A non-top level block tree cannot be added to the workspace.")
+      }
+
+      for block in rootBlock.allBlocksForTree() {
+        if let existingBlockUUID = allBlocks[block.uuid] {
           throw BlocklyError(.illegalState,
-            "Cannot add a block into the workspace with a uuid that is already being used by " +
-            "another block")
+            "A block cannot be added into the workspace with a uuid ('\(existingBlockUUID)') " +
+            "that is already being used by another block.")
+        } else if let existingBlockUUID = newBlocks[block.uuid] {
+          throw BlocklyError(.illegalArgument,
+            "Two blocks with the same uuid ('\(existingBlockUUID)') cannot be added into the " +
+            "workspace at the same time.")
+        } else if block.shadow && block.topLevel {
+          throw BlocklyError(
+            .illegalState, "A shadow block cannot be added to the workspace as a top-level block.")
         }
+
+        newBlocks[block.uuid] = block
       }
 
-      if block.shadow && block.topLevel {
-        throw BlocklyError(
-          .illegalState, "Shadow block cannot be added to the workspace as a top-level block.")
-      }
-
-      newBlocks.append(block)
+      // This block tree passes all checks. Add it to the list.
+      newRootBlocks[rootBlock.uuid] = rootBlock
     }
 
     if let maxBlocks = self.maxBlocks , (allBlocks.count + newBlocks.count) > maxBlocks {
       throw BlocklyError(.workspaceExceedsCapacity,
-        "Adding more blocks would exceed the maximum amount allowed (\(maxBlocks))")
+        "Adding more blocks would exceed the maximum amount allowed (\(maxBlocks)).")
     }
 
     // Fire listeners for all blocks that will be added to the workspace
-    for block in newBlocks {
-      listeners.forEach { $0.workspace?(self, willAddBlock: block) }
-    }
+    let newRootBlockTrees = Array(newRootBlocks.values)
+    listeners.forEach { $0.workspace?(self, willAddBlockTrees: newRootBlockTrees) }
 
     // All checks passed. Add the new blocks to the workspace.
-    for block in newBlocks {
+    for (_, block) in newBlocks {
       block.editable = block.editable && !readOnly
       allBlocks[block.uuid] = block
     }
 
     // Notify delegate for each block addition, now that all of them have been added to the
     // workspace
-    for block in newBlocks {
-      listeners.forEach { $0.workspace?(self, didAddBlock: block) }
-    }
+    listeners.forEach { $0.workspace?(self, didAddBlockTrees: newRootBlockTrees) }
   }
 
   /**
@@ -212,33 +232,37 @@ open class Workspace : NSObject {
    `BlocklyError`: Thrown if the tree of blocks could not be removed from the workspace.
    */
   open func removeBlockTree(_ rootBlock: Block) throws {
-    if (rootBlock.previousConnection?.connected ?? false) ||
-      (rootBlock.outputConnection?.connected ?? false)
-    {
-      throw BlocklyError(.illegalOperation,
-        "The root block must be disconnected from its previous and/or output connections prior " +
-        "to being removed from the workspace")
-    }
+    try removeBlockTrees([rootBlock])
+  }
 
-    var removedBlocks = [Block]()
+  /**
+   Removes a given list of blocks and all of their connected child blocks from the workspace.
 
-    // Figure out which blocks to remove from the workspace and fire listeners
-    for block in rootBlock.allBlocksForTree() {
-      if containsBlock(block) {
-        removedBlocks.append(block)
-        listeners.forEach { $0.workspace?(self, willRemoveBlock: block) }
+   - parameter rootBlocks: The list of root blocks to remove.
+   - throws:
+   `BlocklyError`: Thrown if the list of blocks could not be removed from the workspace.
+   */
+  open func removeBlockTrees(_ rootBlocks: [Block]) throws {
+    for rootBlock in rootBlocks {
+      if !rootBlock.topLevel {
+        throw BlocklyError(.illegalOperation,
+          "A root block must be disconnected from its previous and/or output connections prior " +
+          "to being removed from the workspace.")
       }
     }
 
+    // Fire listeners for block trees that will be removed from the workspace
+    listeners.forEach { $0.workspace?(self, willRemoveBlockTrees: rootBlocks) }
+
     // Remove blocks at the same time
-    for block in removedBlocks {
-      allBlocks[block.uuid] = nil
+    for rootBlock in rootBlocks {
+      for block in rootBlock.allBlocksForTree() {
+        allBlocks[block.uuid] = nil
+      }
     }
 
     // Fire listeners for all blocks that were removed
-    for block in removedBlocks {
-      listeners.forEach { $0.workspace?(self, didRemoveBlock: block) }
-    }
+    listeners.forEach { $0.workspace?(self, didRemoveBlockTrees: rootBlocks) }
   }
 
   /**

--- a/Sources/Model/XML/Workspace+XML.swift
+++ b/Sources/Model/XML/Workspace+XML.swift
@@ -46,10 +46,14 @@ extension Workspace {
    */
   public func loadBlocks(fromXML xml: AEXMLElement, factory: BlockFactory) throws {
     if let allBlocksXML = xml["block"].all {
+      var blockTrees = Array<Block.BlockTree>()
+
       for blockXML in allBlocksXML {
         let blockTree = try Block.blockTree(fromXML: blockXML, factory: factory)
-        try addBlockTree(blockTree.rootBlock)
+        blockTrees.append(blockTree)
       }
+
+      try addBlockTrees(blockTrees.map({ $0.rootBlock }))
     }
   }
 }

--- a/Sources/UI/Views/FieldAngleView.swift
+++ b/Sources/UI/Views/FieldAngleView.swift
@@ -137,7 +137,12 @@ extension FieldAngleView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    EventManager.sharedInstance.groupAndFireEvents {
+    // Group and fire with any existing group. This solves an edge-case problem where dragging a
+    // block while editing a text field could simultaneously start two new event groups (one for
+    // the drag gesture and the other for ending text field editing). To prevent this from
+    // happening, this method simply appends to any existing one instead (if it exists).
+    let eventManager = EventManager.sharedInstance
+    eventManager.groupAndFireEvents(groupID: eventManager.currentGroupID) {
       // Only commit the change after the user has finished editing the field
       fieldAngleLayout?.updateAngle(fromText: (textField.text ?? ""))
 

--- a/Sources/UI/Views/FieldInputView.swift
+++ b/Sources/UI/Views/FieldInputView.swift
@@ -114,7 +114,12 @@ extension FieldInputView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    EventManager.sharedInstance.groupAndFireEvents {
+    // Group and fire with any existing group. This solves an edge-case problem where dragging a
+    // block while editing a text field could simultaneously start two new event groups (one for
+    // the drag gesture and the other for ending text field editing). To prevent this from
+    // happening, this method simply appends to any existing one instead (if it exists).
+    let eventManager = EventManager.sharedInstance
+    eventManager.groupAndFireEvents(groupID: eventManager.currentGroupID) {
       // Only commit the change after the user has finished editing the field
       fieldInputLayout?.updateText(self.textField.text ?? "")
     }

--- a/Sources/UI/Views/FieldNumberView.swift
+++ b/Sources/UI/Views/FieldNumberView.swift
@@ -145,7 +145,12 @@ extension FieldNumberView: UITextFieldDelegate {
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
-    EventManager.sharedInstance.groupAndFireEvents {
+    // Group and fire with any existing group. This solves an edge-case problem where dragging a
+    // block while editing a text field could simultaneously start two new event groups (one for
+    // the drag gesture and the other for ending text field editing). To prevent this from
+    // happening, this method simply appends to any existing one instead (if it exists).
+    let eventManager = EventManager.sharedInstance
+    eventManager.groupAndFireEvents(groupID: eventManager.currentGroupID) {
       // Only commit the change after the user has finished editing the field
       fieldNumberLayout?.setValueFromLocalizedText(self.textField.text ?? "")
 

--- a/Tests/Sources/Core/Common/CodeGeneratorServiceTest.swift
+++ b/Tests/Sources/Core/Common/CodeGeneratorServiceTest.swift
@@ -77,15 +77,17 @@ class CodeGeneratorServiceTest: XCTestCase {
     builder.addJSONBlockDefinitionFiles(fromDefaultFiles: .allDefault)
     _codeGeneratorService.setRequestBuilder(builder, shouldCache: false)
 
+    let abc = ""
+
     // Execute request
     let _ = BKYAssertDoesNotThrow {
       try _codeGeneratorService.generateCode(
         forWorkspace: workspace,
-        onCompletion: { code in
+        onCompletion: { _, code in
           XCTAssertEqual("for count in range(10):  pass",
                          code.replacingOccurrences(of: "\n", with: ""))
           expectation.fulfill()
-        }, onError: { error in
+        }, onError: { _, error in
           XCTFail("Error occurred during code generation: \(error)")
           expectation.fulfill()
       })
@@ -140,11 +142,11 @@ class CodeGeneratorServiceTest: XCTestCase {
       let _ = BKYAssertDoesNotThrow {
         try _codeGeneratorService.generateCode(
           forWorkspace: workspace,
-          onCompletion: { code in
+          onCompletion: { _, code in
             XCTAssertEqual("for count in range(10):  pass",
                            code.replacingOccurrences(of: "\n", with: ""))
             expectation.fulfill()
-          }, onError: { error in
+          }, onError: { _, error in
             XCTFail("Error occurred during code generation: \(error)")
             expectation.fulfill()
           })
@@ -205,10 +207,10 @@ class CodeGeneratorServiceTest: XCTestCase {
     let _ = BKYAssertDoesNotThrow {
       try _codeGeneratorService.generateCode(
         forWorkspace: workspace,
-        onCompletion: { code in
+        onCompletion: { _, code in
           XCTAssertEqual("#abcdef", code)
           expectation.fulfill()
-        }, onError: { error in
+        }, onError: { _, error in
           XCTFail("Error occurred during code generation: \(error)")
           expectation.fulfill()
         })
@@ -272,11 +274,11 @@ class CodeGeneratorServiceTest: XCTestCase {
     let _ = BKYAssertDoesNotThrow {
       try _codeGeneratorService.generateCode(
         forWorkspace: workspace,
-        onCompletion: { code in
+        onCompletion: { _, code in
           XCTAssertEqual("if (false) {} else if (false) {} else if (true) {}",
                          code.replacingOccurrences(of: "\n", with: ""))
           expectation.fulfill()
-      }, onError: { error in
+      }, onError: { _, error in
         XCTFail("Error occurred during code generation: \(error)")
         expectation.fulfill()
       })


### PR DESCRIPTION
- Fixes bug with procedure coordinator where it could auto-create a d…efinition block when it wasn't needed (#383)

- Changes Workspace to better handle simultaneous block tree additions/removals
- Changes WorkspaceListener to match new method implementations
- Fixes edge-case bug where dragging a block while editing text field would create two event groups
- Fixes CodeGeneratorServiceTest to match new signatures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/386)
<!-- Reviewable:end -->
