### PR TITLE
- Changes code so editable property is never used in model/layout cod…

### DIFF
--- a/Sources/Layout/BlockLayout.swift
+++ b/Sources/Layout/BlockLayout.swift
@@ -140,13 +140,15 @@ open class BlockLayout: Layout {
   open var disabled: Bool {
     get { return block.disabled }
     set {
-      if block.editable {
-        block.disabled = disabled
+      if block.disabled == newValue {
+        return
+      }
 
-        if let workspace = self.workspace {
-          let event = BlocklyEvent.Change.disabledStateEvent(workspace: workspace, block: block)
-          EventManager.shared.addPendingEvent(event)
-        }
+      block.disabled = newValue
+
+      if let workspace = self.workspace {
+        let event = BlocklyEvent.Change.disabledStateEvent(workspace: workspace, block: block)
+        EventManager.shared.addPendingEvent(event)
       }
     }
   }
@@ -156,13 +158,15 @@ open class BlockLayout: Layout {
   open var inputsInline: Bool {
     get { return block.inputsInline }
     set {
-      if block.editable && block.inputsInline != newValue {
-        block.inputsInline = newValue
+      if block.inputsInline == newValue {
+        return
+      }
 
-        if let workspace = self.workspace {
-          let event = BlocklyEvent.Change.inlineStateEvent(workspace: workspace, block: block)
-          EventManager.shared.addPendingEvent(event)
-        }
+      block.inputsInline = newValue
+
+      if let workspace = self.workspace {
+        let event = BlocklyEvent.Change.inlineStateEvent(workspace: workspace, block: block)
+        EventManager.shared.addPendingEvent(event)
       }
     }
   }
@@ -171,15 +175,17 @@ open class BlockLayout: Layout {
   open var comment: String {
     get { return block.comment }
     set {
-      if block.editable && block.comment != newValue {
-        let oldValue = block.comment
-        block.comment = newValue
+      if block.comment == newValue {
+        return
+      }
 
-        if let workspace = self.workspace {
-          let event = BlocklyEvent.Change.commentTextEvent(
-            workspace: workspace, block: block, oldValue: oldValue, newValue: newValue)
-          EventManager.shared.addPendingEvent(event)
-        }
+      let oldValue = block.comment
+      block.comment = newValue
+
+      if let workspace = self.workspace {
+        let event = BlocklyEvent.Change.commentTextEvent(
+          workspace: workspace, block: block, oldValue: oldValue, newValue: newValue)
+        EventManager.shared.addPendingEvent(event)
       }
     }
   }

--- a/Sources/Layout/FieldAngleLayout.swift
+++ b/Sources/Layout/FieldAngleLayout.swift
@@ -24,7 +24,7 @@ open class FieldAngleLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldAngle` that backs this layout
-  open let fieldAngle: FieldAngle
+  private let fieldAngle: FieldAngle
 
   /// The text value that should be used when rendering this layout
   open var textValue: String {
@@ -47,7 +47,6 @@ open class FieldAngleLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldCheckboxLayout.swift
+++ b/Sources/Layout/FieldCheckboxLayout.swift
@@ -24,7 +24,7 @@ open class FieldCheckboxLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldCheckbox` that backs this layout
-  open let fieldCheckbox: FieldCheckbox
+  private let fieldCheckbox: FieldCheckbox
 
   /// The checkbox value that should be used when rendering this layout
   open var checked: Bool {
@@ -49,7 +49,6 @@ open class FieldCheckboxLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldColorLayout.swift
+++ b/Sources/Layout/FieldColorLayout.swift
@@ -24,7 +24,7 @@ open class FieldColorLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldColor` that backs this layout
-  open let fieldColor: FieldColor
+  private let fieldColor: FieldColor
 
   /// The checkbox value that should be used when rendering this layout
   open var color: UIColor {
@@ -47,7 +47,6 @@ open class FieldColorLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldDateLayout.swift
+++ b/Sources/Layout/FieldDateLayout.swift
@@ -24,7 +24,7 @@ open class FieldDateLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldDate` that backs this layout
-  open let fieldDate: FieldDate
+  private let fieldDate: FieldDate
 
   /// The value that should be used when rendering this layout
   open var textValue: String {
@@ -67,7 +67,6 @@ open class FieldDateLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldDropdownLayout.swift
+++ b/Sources/Layout/FieldDropdownLayout.swift
@@ -24,7 +24,7 @@ open class FieldDropdownLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldDropdown` that backs this layout
-  open let fieldDropdown: FieldDropdown
+  private let fieldDropdown: FieldDropdown
 
   /// The list of options that should be presented when rendering this layout
   open var options: [FieldDropdown.Option] {
@@ -59,7 +59,6 @@ open class FieldDropdownLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldImageLayout.swift
+++ b/Sources/Layout/FieldImageLayout.swift
@@ -24,7 +24,7 @@ open class FieldImageLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldImage` that backs this layout
-  open let fieldImage: FieldImage
+  private let fieldImage: FieldImage
 
   /// The size of the image field, expressed as a Workspace coordinate system size
   open var size: WorkspaceSize {
@@ -47,7 +47,6 @@ open class FieldImageLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldInputLayout.swift
+++ b/Sources/Layout/FieldInputLayout.swift
@@ -24,7 +24,7 @@ open class FieldInputLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldInput` that backs this layout
-  open let fieldInput: FieldInput
+  private let fieldInput: FieldInput
 
   /// The current text value that should be used when rendering this layout.
   /// This value is automatically set to `self.fieldInput.text` on initialization and
@@ -55,8 +55,6 @@ open class FieldInputLayout: FieldLayout {
   }
 
   // MARK: - Super
-
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
 
   open override func didUpdateField(_ field: Field) {
     // Update current text value to match the field now

--- a/Sources/Layout/FieldLabelLayout.swift
+++ b/Sources/Layout/FieldLabelLayout.swift
@@ -24,7 +24,7 @@ open class FieldLabelLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldLabel` that backs this layout
-  open let fieldLabel: FieldLabel
+  private let fieldLabel: FieldLabel
 
   /// The value that should be used when rendering this layout
   open var text: String {
@@ -47,7 +47,6 @@ open class FieldLabelLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     // Perform a layout up the tree
     updateLayoutUpTree()

--- a/Sources/Layout/FieldLayout.swift
+++ b/Sources/Layout/FieldLayout.swift
@@ -132,7 +132,7 @@ open class FieldLayout: Layout {
   }
 }
 
-// MARK: - FieldDelegate implementation
+// MARK: - FieldListener implementation
 
 extension FieldLayout: FieldListener {
   public func didUpdateField(_ field: Field) {

--- a/Sources/Layout/FieldNumberLayout.swift
+++ b/Sources/Layout/FieldNumberLayout.swift
@@ -24,7 +24,7 @@ open class FieldNumberLayout: FieldLayout {
   // MARK: - Properties
 
   /// The target `FieldNumber` to lay out
-  open let fieldNumber: FieldNumber
+  private let fieldNumber: FieldNumber
 
   /// The current text value that should be used to render the `FieldNumber`.
   /// This value is automatically set to `self.fieldNumber.textValue` on initialization and 

--- a/Sources/Layout/FieldVariableLayout.swift
+++ b/Sources/Layout/FieldVariableLayout.swift
@@ -29,7 +29,7 @@ open class FieldVariableLayout: FieldLayout {
   // MARK: - Properties
 
   /// The `FieldVariable` that backs this layout
-  open let fieldVariable: FieldVariable
+  private let fieldVariable: FieldVariable
 
   /// The list of all variable options that should be presented when rendering this layout
   open var variables: [Option] {
@@ -89,7 +89,6 @@ open class FieldVariableLayout: FieldLayout {
 
   // MARK: - Super
 
-  // TODO(#114): Remove `override` once `FieldLayout` is deleted.
   open override func didUpdateField(_ field: Field) {
     if let nameManager = self.nameManager,
       !nameManager.containsName(variable)

--- a/Sources/Layout/MutatorLayout.swift
+++ b/Sources/Layout/MutatorLayout.swift
@@ -29,6 +29,11 @@ open class MutatorLayout: Layout {
   /// to this mutator.
   open weak var layoutCoordinator: WorkspaceLayoutCoordinator?
 
+  /// Flag determining if user interaction should be enabled for the corresponding view.
+  public var userInteractionEnabled: Bool {
+    return mutator.block?.editable ?? false
+  }
+
   // MARK: - Initializers
 
   /**

--- a/Sources/Model/Block.swift
+++ b/Sources/Model/Block.swift
@@ -53,7 +53,7 @@ public final class Block : NSObject {
   /// Flag indicating if input connectors should be drawn inside a block (`true`) or
   /// on the edge of the block (`false`)
   public var inputsInline: Bool {
-    didSet { didSetEditableProperty(&inputsInline, oldValue) }
+    didSet { didSetProperty(inputsInline, oldValue) }
   }
   /// The absolute position of the block, in the Workspace coordinate system
   public var position: WorkspacePoint
@@ -104,15 +104,15 @@ public final class Block : NSObject {
   public var mutator: Mutator?
   /// Tooltip text of the block
   public var tooltip: String {
-    didSet { didSetEditableProperty(&tooltip, oldValue) }
+    didSet { didSetProperty(tooltip, oldValue) }
   }
   /// The comment text of the block
   public var comment: String {
-    didSet { didSetEditableProperty(&comment, oldValue) }
+    didSet { didSetProperty(comment, oldValue) }
   }
   /// A help URL to learn more info about this block
   public var helpURL: String {
-    didSet { didSetEditableProperty(&helpURL, oldValue) }
+    didSet { didSetProperty(helpURL, oldValue) }
   }
   /// Flag indicating if this block may be deleted
   public var deletable: Bool {
@@ -139,6 +139,7 @@ public final class Block : NSObject {
       }
 
       updateInputs()
+      notifyDidUpdateBlock()
     }
   }
 
@@ -411,63 +412,25 @@ public final class Block : NSObject {
   }
 
   /**
-   A convenience method that should be called inside the `didSet { ... }` block of editable instance
-   properties.
-
-   If `self.editable == true` and `editableProperty != oldValue`, this method will automatically
-   call `delegate?.didUpdateBlock(self)`.
-
-   If `self.editable == true` and `editableProperty == oldValue`, nothing happens.
-
-   If `self.editable == false`, this method automatically reverts `editableProperty` back to
-   `oldValue`.
-
-   Usage:
-   ```
-   var someEditableInteger: Int {
-   didSet { didSetEditableProperty(&someEditableInteger, oldValue) }
-   }
-   ```
-
-   - parameter editableProperty: The instance property that had been set
-   - parameter oldValue: The old value of the instance property
-   - returns: `true` if `editableProperty` is now different than `oldValue`, `false` otherwise.
-   */
-  @discardableResult
-  public func didSetEditableProperty<T: Equatable>(
-    _ editableProperty: inout T, _ oldValue: T) -> Bool
-  {
-    if !self.editable {
-      editableProperty = oldValue
-    }
-    if editableProperty == oldValue {
-      return false
-    }
-    notifyDidUpdateBlock()
-    return true
-  }
-
-  /**
    A convenience method that should be called inside the `didSet { ... }` block of instance
    properties.
 
-   If `property != oldValue`, this method will automatically call `delegate?.didUpdateBlock(self)`.
-   If `editableProperty == oldValue`, nothing happens.
+   If `property != oldValue`, this method will automatically call `notifyDidUpdateBlock()`.
+   If `property == oldValue`, nothing happens.
 
    Usage:
    ```
    var someString: String {
-   didSet { didSetProperty(someString, oldValue) }
+     didSet { didSetProperty(someString, oldValue) }
    }
    ```
 
-   - parameter property: The instance property that had been set
-   - parameter oldValue: The old value of the instance property
-   - returns: `true` if `property` is now different than `oldValue`, `false` otherwise.
+   - parameter property: The instance property that had been set.
+   - parameter oldValue: The old value of the instance property.
+   - returns: `true` if `property` is now different than `oldValue`. `false` otherwise.
    */
   @discardableResult
-  public func didSetProperty<T: Equatable>(
-    _ property: T, _ oldValue: T) -> Bool {
+  public func didSetProperty<T: Equatable>(_ property: T, _ oldValue: T) -> Bool {
     if property == oldValue {
       return false
     }

--- a/Sources/Model/Field.swift
+++ b/Sources/Model/Field.swift
@@ -113,33 +113,23 @@ open class Field: NSObject {
    A convenience method that should be called inside the `didSet { ... }` block of instance
    properties from `Field` subclasses.
 
-   If `self.editable == true` and `editableProperty != oldValue`, this method will automatically
-   call `delegate?.didUpdateField(self)`.
-
-   If `self.editable == true` and `editableProperty == oldValue`, nothing happens.
-
-   If `self.editable == false`, this method automatically reverts `editableProperty` back to
-   `oldValue`.
+   If `property != oldValue`, this method will automatically call `notifyDidUpdateField()`.
+   If `property == oldValue`, nothing happens.
 
    Usage:
    ```
-   var someInteger: Int {
-     didSet { didSetEditableProperty(&someInteger, oldValue) }
+   var someString: String {
+     didSet { didSetProperty(someString, oldValue) }
    }
    ```
 
-   - parameter editableProperty: The instance property that had been set
-   - parameter oldValue: The old value of the instance property
-   - returns: `true` if `editableProperty` is now different than `oldValue`, `false` otherwise.
+   - parameter property: The instance property that had been set.
+   - parameter oldValue: The old value of the instance property.
+   - returns: `true` if `property` is now different than `oldValue`. `false` otherwise.
    */
   @discardableResult
-  open func didSetEditableProperty<T: Equatable>(
-    _ editableProperty: inout T, _ oldValue: T) -> Bool
-  {
-    if !self.editable {
-      editableProperty = oldValue
-    }
-    if editableProperty == oldValue {
+  open func didSetProperty<T: Equatable>(_ property: T, _ oldValue: T) -> Bool {
+    if property == oldValue {
       return false
     }
     notifyDidUpdateField()
@@ -150,33 +140,23 @@ open class Field: NSObject {
    A convenience method that should be called inside the `didSet { ... }` block of instance
    properties from `Field` subclasses.
 
-   If `self.editable == true` and `editableProperty != oldValue`, this method will automatically
-   call `delegate?.didUpdateField(self)`.
-
-   If `self.editable == true` and `editableProperty == oldValue`, nothing happens.
-
-   If `self.editable == false`, this method automatically reverts `editableProperty` back to
-   `oldValue`.
+   If `property != oldValue`, this method will automatically call `notifyDidUpdateField()`.
+   If `property == oldValue`, nothing happens.
 
    Usage:
    ```
-   var someInteger: Int {
-     didSet { didSetEditableProperty(&someInteger, oldValue) }
+   var someNullableString: String? {
+     didSet { didSetProperty(someNullableString, oldValue) }
    }
    ```
 
-   - parameter editableProperty: The instance property that had been set
-   - parameter oldValue: The old value of the instance property
-   - returns: `true` if `editableProperty` is now different than `oldValue`, `false` otherwise.
+   - parameter property: The instance property that had been set.
+   - parameter oldValue: The old value of the instance property.
+   - returns: `true` if `property` is now different than `oldValue`. `false` otherwise.
    */
   @discardableResult
-  open func didSetEditableProperty<T: Equatable>(
-    _ editableProperty: inout T?, _ oldValue: T?) -> Bool
-  {
-    if !self.editable {
-      editableProperty = oldValue
-    }
-    if editableProperty == oldValue {
+  open func didSetProperty<T: Equatable>(_ property: T?, _ oldValue: T?) -> Bool {
+    if property == oldValue {
       return false
     }
     notifyDidUpdateField()

--- a/Sources/Model/FieldAngle.swift
+++ b/Sources/Model/FieldAngle.swift
@@ -27,7 +27,7 @@ public final class FieldAngle: Field {
     didSet {
       // Normalize the value that was set
       angle = FieldAngle.normalizeAngle(angle)
-      didSetEditableProperty(&angle, oldValue)
+      didSetProperty(angle, oldValue)
     }
   }
 

--- a/Sources/Model/FieldCheckbox.swift
+++ b/Sources/Model/FieldCheckbox.swift
@@ -24,7 +24,7 @@ public final class FieldCheckbox: Field {
 
   /// `true` if the checkbox field is checked, `false` if it is not.
   public var checked: Bool {
-    didSet { didSetEditableProperty(&checked, oldValue) }
+    didSet { didSetProperty(checked, oldValue) }
   }
 
   // MARK: - Initializers

--- a/Sources/Model/FieldColor.swift
+++ b/Sources/Model/FieldColor.swift
@@ -24,7 +24,7 @@ public final class FieldColor: Field {
 
   /// The `UIColor` of this field.
   public var color: UIColor {
-    didSet { didSetEditableProperty(&color, oldValue) }
+    didSet { didSetProperty(color, oldValue) }
   }
 
   // MARK: - Initializers

--- a/Sources/Model/FieldDropdown.swift
+++ b/Sources/Model/FieldDropdown.swift
@@ -40,7 +40,7 @@ public final class FieldDropdown: Field {
 
   /// The currently selected index
   public var selectedIndex: Int {
-    didSet { didSetEditableProperty(&selectedIndex, oldValue) }
+    didSet { didSetProperty(selectedIndex, oldValue) }
   }
 
   /// The option tuple of the currently selected index

--- a/Sources/Model/FieldImage.swift
+++ b/Sources/Model/FieldImage.swift
@@ -24,7 +24,7 @@ public final class FieldImage: Field {
 
   /// The `WorkspaceSize` of this field.
   public var size: WorkspaceSize {
-    didSet { didSetEditableProperty(&size, oldValue) }
+    didSet { didSetProperty(size, oldValue) }
   }
   /**
    The location of the image in this field.
@@ -34,11 +34,11 @@ public final class FieldImage: Field {
    of a URL web image to fetch.
    */
   public var imageLocation: String {
-    didSet { didSetEditableProperty(&imageLocation, oldValue) }
+    didSet { didSetProperty(imageLocation, oldValue) }
   }
   /// The alt text for this field.
   public var altText: String {
-    didSet { didSetEditableProperty(&altText, oldValue) }
+    didSet { didSetProperty(altText, oldValue) }
   }
 
   // MARK: - Initializers

--- a/Sources/Model/FieldInput.swift
+++ b/Sources/Model/FieldInput.swift
@@ -24,7 +24,7 @@ public final class FieldInput: Field {
 
   /// The text value for the field
   public var text: String {
-    didSet { didSetEditableProperty(&text, oldValue) }
+    didSet { didSetProperty(text, oldValue) }
   }
 
   // MARK: - Initializers

--- a/Sources/Model/FieldNumber.swift
+++ b/Sources/Model/FieldNumber.swift
@@ -48,7 +48,7 @@ public final class FieldNumber: Field {
   public var value: Double {
     didSet {
       value = constrainedValue(value) // Make sure the new value is constrained
-      didSetEditableProperty(&value, oldValue)
+      didSetProperty(value, oldValue)
     }
   }
   /// The localized text representation of `self.value`
@@ -57,11 +57,11 @@ public final class FieldNumber: Field {
   }
   /// The minimum value of `self.value`. If `nil`, `self.value` is unconstrained by a minimum value.
   public fileprivate(set) var minimumValue: Double? = nil {
-    didSet { didSetEditableProperty(&minimumValue, oldValue) }
+    didSet { didSetProperty(minimumValue, oldValue) }
   }
   /// The maximum value of `self.value`. If `nil`, `self.value` is unconstrained by a maximum value.
   public fileprivate(set) var maximumValue: Double? = nil {
-    didSet { didSetEditableProperty(&maximumValue, oldValue) }
+    didSet { didSetProperty(maximumValue, oldValue) }
   }
   /**
    The precision of the value allowed by this field.
@@ -73,7 +73,7 @@ public final class FieldNumber: Field {
    */
   public fileprivate(set) var precision: Double? = nil {
     didSet {
-      if didSetEditableProperty(&self.precision, oldValue) {
+      if didSetProperty(precision, oldValue) {
         updateNumberFormatter()
       }
     }

--- a/Sources/UI/Views/MutatorIfElseView.swift
+++ b/Sources/UI/Views/MutatorIfElseView.swift
@@ -67,7 +67,7 @@ open class MutatorIfElseView: LayoutView {
   {
     super.refreshView(forFlags: flags, animated: animated)
 
-    guard let layout = self.layout else {
+    guard let layout = self.mutatorIfElseLayout else {
       return
     }
 
@@ -79,6 +79,8 @@ open class MutatorIfElseView: LayoutView {
 
       let topPadding = layout.engine.viewUnitFromWorkspaceUnit(4)
       self.popoverButton.contentEdgeInsets = UIEdgeInsetsMake(topPadding, 0, topPadding, 0)
+
+      self.isUserInteractionEnabled = layout.userInteractionEnabled
     }
   }
 

--- a/Sources/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Sources/UI/Views/MutatorProcedureDefinitionView.swift
@@ -68,7 +68,7 @@ open class MutatorProcedureDefinitionView: LayoutView {
   {
     super.refreshView(forFlags: flags, animated: animated)
 
-    guard let layout = self.layout else {
+    guard let layout = self.mutatorProcedureDefinitionLayout else {
       return
     }
 
@@ -80,6 +80,8 @@ open class MutatorProcedureDefinitionView: LayoutView {
 
       let topPadding = layout.engine.viewUnitFromWorkspaceUnit(4)
       self.popoverButton.contentEdgeInsets = UIEdgeInsetsMake(topPadding, 0, topPadding, 0)
+
+      self.isUserInteractionEnabled = layout.userInteractionEnabled
     }
   }
 


### PR DESCRIPTION
…e, and is instead used at the view level.

- Hides underlying Field model objects from FieldLayout subclasses

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/393)
<!-- Reviewable:end -->
