### PR TITLE
Removes warning when setting field xml with an empty value since it c…

### DIFF
--- a/Sources/Model/XML/Block+XML.swift
+++ b/Sources/Model/XML/Block+XML.swift
@@ -230,12 +230,7 @@ extension Block {
       return
     }
 
-    guard let value = xml.value else {
-      bky_print("Skipping setting field for block type '\(block.name)'. " +
-        "Missing value for field:\n\(xml.xmlCompact)")
-      return
-    }
-
+    let value = xml.value ?? ""
     try field.setValueFromSerializedText(value)
   }
 }


### PR DESCRIPTION
…ould represent the empty string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/394)
<!-- Reviewable:end -->
