### PR TITLE
initial check for blockly-ios travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ matrix:
       objective-c: "stable"
 
 script:
-  xcodebuild test -project Samples/BlocklySample/BlocklySample.xcodeproj  -scheme BlocklyTests  -destination 'platform=iOS Simulator,name=iPad Air,OS=9.3' 
+  xcodebuild test -project Samples/BlocklySample/BlocklySample.xcodeproj  -scheme BlocklyTests
+                  -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3'
+                  -destination 'platform=iOS Simulator,name=iPad Air,OS=10.3'
+                  -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch),OS=10.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: objective-c
 matrix:
   include:
@@ -7,5 +8,5 @@ matrix:
 script:
   xcodebuild test -project Samples/BlocklySample/BlocklySample.xcodeproj  -scheme BlocklyTests
                   -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3'
-                  -destination 'platform=iOS Simulator,name=iPad Air,OS=10.3'
-                  -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch),OS=10.3'
+                  -destination 'platform=iOS Simulator,name=iPad 2,OS=8.3'
+                  -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch),OS=9.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
   include:
     - osx_image: xcode8.3
       objective-c: "stable"
-    - osx_image: Xcode 7.3.1
-      objective-c: "stable"
+    #- osx_image: Xcode 7.3.1
+    #  objective-c: "stable"
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: objective-c
+#xcode_project:  Samples/BlocklySample/BlocklySample.xcodeproj
+#xcode_scheme: BlocklyTests
+
+matrix:
+  include:
+    - osx_image: xcode8.3
+      objective-c: "stable"
+    - osx_image: Xcode 7.3.1
+      objective-c: "stable"
+
+
+script:
+  xcodebuild test -project Samples/BlocklySample/BlocklySample.xcodeproj  -scheme BlocklyTests  -destination 'platform=iOS Simulator,name=iPad Air,OS=9.3' 
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: objective-c
-#xcode_project:  Samples/BlocklySample/BlocklySample.xcodeproj
-#xcode_scheme: BlocklyTests
-
 matrix:
   include:
     - osx_image: xcode8.3
       objective-c: "stable"
-    #- osx_image: Xcode 7.3.1
-    #  objective-c: "stable"
-
 
 script:
   xcodebuild test -project Samples/BlocklySample/BlocklySample.xcodeproj  -scheme BlocklyTests  -destination 'platform=iOS Simulator,name=iPad Air,OS=9.3' 
-  


### PR DESCRIPTION
This is blockly-ios travis build config. It's currently it runs  on blockly-test test target and will make build failed for any test failure. 

1. test run with xcode 8.3 and 7.3.1 with emulator ipad air on ios=10.3. 
2. it's running in parallel and average run time under 1 minutes. about 40 seconds. 

Here's my travis job: https://travis-ci.org/shirletan/blockly-ios/builds/233391321

Let me know if you want to add more test matrix. It's easy to add more test coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/409)
<!-- Reviewable:end -->
