### PR TITLE
- Normalized field heights so blocks are closer in height.

### DIFF
--- a/Sources/Control/Dragger.swift
+++ b/Sources/Control/Dragger.swift
@@ -76,8 +76,7 @@ public final class Dragger: NSObject {
         try workspaceLayoutCoordinator.disconnect(outputConnection)
       }
 
-      // Highlight this block
-      layout.highlighted = true
+      // Mark the block group as being dragged.
       layout.rootBlockGroupLayout?.dragging = true
 
       // Bring its block group layout to the front
@@ -164,8 +163,7 @@ public final class Dragger: NSObject {
         EventManager.shared.addPendingEvent(drag.moveEvent)
       }
 
-      // Remove the highlight for this block
-      layout.highlighted = false
+      // Unmark this block group as being dragged.
       layout.rootBlockGroupLayout?.dragging = false
 
       // If this block can be connected to anything, connect it.

--- a/Sources/Layout/Default/DefaultLayoutConfig.swift
+++ b/Sources/Layout/Default/DefaultLayoutConfig.swift
@@ -108,7 +108,7 @@ open class DefaultLayoutConfig: LayoutConfig {
     setUnit(Unit(4), for: DefaultLayoutConfig.NotchHeight)
     setUnit(Unit(10), for: DefaultLayoutConfig.StatementSectionHeight)
     setUnit(Unit(10), for: DefaultLayoutConfig.StatementMinimumConnectorWidth)
-    setSize(Size(10, 25), for: DefaultLayoutConfig.MinimumInlineConnectorSize)
+    setSize(Size(width: 12, height: 28), for: DefaultLayoutConfig.MinimumInlineConnectorSize)
 
     setColor(UIColor.darkGray, for: DefaultLayoutConfig.BlockStrokeDefaultColor)
     setColor(UIColor.blue, for: DefaultLayoutConfig.BlockStrokeHighlightColor)
@@ -124,6 +124,6 @@ open class DefaultLayoutConfig: LayoutConfig {
     setFloat(1.2, for: DefaultLayoutConfig.BlockShadowBrightnessMultiplier)
 
     setBool(false, for: DefaultLayoutConfig.BlockStartHat)
-    setSize(Size(100, 15), for: DefaultLayoutConfig.BlockStartHatSize)
+    setSize(Size(width: 100, height: 16), for: DefaultLayoutConfig.BlockStartHatSize)
   }
 }

--- a/Sources/Layout/LayoutConfig.swift
+++ b/Sources/Layout/LayoutConfig.swift
@@ -88,6 +88,9 @@ open class LayoutConfig: NSObject {
   /// [`Font`] The default font to use for generic text inside Blockly.
   public static let GlobalFont = LayoutConfig.newPropertyKey()
 
+  /// [`Size`] For mutators, this is the size of the default "settings" button.
+  public static let MutatorButtonSize = LayoutConfig.newPropertyKey()
+
   /// [`Font`] The font to use for title text inside popovers.
   public static let PopoverTitleFont = LayoutConfig.newPropertyKey()
 
@@ -123,6 +126,10 @@ open class LayoutConfig: NSObject {
   /// system and UIView coordinate system.
   public typealias Size = LayoutConfigSize
 
+  /// Struct for representing an `EdgeInsets` value in both the Workspace coordinate system and
+  /// UIView coordinate system.
+  public typealias ScaledEdgeInsets = LayoutConfigEdgeInsets
+
   // MARK: - Properties
 
   // The current scale of all values inside the config
@@ -143,8 +150,8 @@ open class LayoutConfig: NSObject {
   /// Dictionary mapping property keys to `Double` values
   public private(set) var doubles = Dictionary<PropertyKey, Double>()
 
-  /// Dictionary mapping property keys to `EdgeInsets` values
-  public private(set) var edgeInsets = Dictionary<PropertyKey, EdgeInsets>()
+  /// Dictionary mapping property keys to `ScaledEdgeInsets` values
+  public private(set) var edgeInsets = Dictionary<PropertyKey, ScaledEdgeInsets>()
 
   /// Dictionary mapping property keys to `CGFloat` values
   public private(set) var floats = Dictionary<PropertyKey, CGFloat>()
@@ -171,20 +178,20 @@ open class LayoutConfig: NSObject {
     super.init()
 
     // Set default values for base config keys
-    setUnit(Unit(25), for: LayoutConfig.BlockBumpDistance)
-    setUnit(Unit(25), for: LayoutConfig.BlockSnapDistance)
-    setUnit(Unit(10), for: LayoutConfig.InlineXPadding)
-    setUnit(Unit(5), for: LayoutConfig.InlineYPadding)
+    setUnit(Unit(24), for: LayoutConfig.BlockBumpDistance)
+    setUnit(Unit(24), for: LayoutConfig.BlockSnapDistance)
+    setUnit(Unit(8), for: LayoutConfig.InlineXPadding)
+    setUnit(Unit(4), for: LayoutConfig.InlineYPadding)
     setUnit(Unit(10), for: LayoutConfig.WorkspaceFlowXSeparatorSpace)
     setUnit(Unit(10), for: LayoutConfig.WorkspaceFlowYSeparatorSpace)
 
-    setUnit(Unit(18), for: LayoutConfig.FieldMinimumHeight)
+    setUnit(Unit(30), for: LayoutConfig.FieldMinimumHeight)
     setUnit(Unit(5), for: LayoutConfig.FieldCornerRadius)
     setUnit(Unit(1), for: LayoutConfig.FieldLineWidth)
 
     setUntypedValue(AnglePicker.Options(), for: LayoutConfig.FieldAnglePickerOptions)
 
-    setSize(Size(36, 36), for: LayoutConfig.FieldColorButtonSize)
+    setSize(Size(width: 30, height: 30), for: LayoutConfig.FieldColorButtonSize)
     setUnit(Unit(2), for: LayoutConfig.FieldColorButtonBorderWidth)
 
     // Use the default system colors by setting these config values to nil
@@ -193,9 +200,11 @@ open class LayoutConfig: NSObject {
     setColor(.black, for: LayoutConfig.FieldLabelTextColor)
     setColor(.black, for: LayoutConfig.FieldEditableTextColor)
 
-    setEdgeInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8),
-                  for: LayoutConfig.FieldTextFieldInsetPadding)
+    setScaledEdgeInsets(ScaledEdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8),
+                        for: LayoutConfig.FieldTextFieldInsetPadding)
     setUnit(Unit(300), for: LayoutConfig.FieldTextFieldMaximumWidth)
+
+    setSize(Size(width: 30, height: 30), for: LayoutConfig.MutatorButtonSize)
 
     setDouble(0.3, for: LayoutConfig.ViewAnimationDuration)
 
@@ -307,31 +316,67 @@ open class LayoutConfig: NSObject {
   }
 
   /**
-   Maps a `EdgeInsets` value to a specific `PropertyKey`.
+   Maps a `ScaledEdgeInsets` value to a specific `PropertyKey`.
 
-   - parameter edgeInsets: The `EdgeInsets` value
+   - parameter edgeInsets: The `ScaledEdgeInsets` value
    - parameter key: The `PropertyKey` (e.g. `LayoutConfig.FieldTextFieldInsetPadding`)
-   - returns: The `edgeInset` that was set.
+   - returns: The `edgeInsets` value.
    */
   @discardableResult
-  public func setEdgeInsets(_ edgeInsets: EdgeInsets, for key: PropertyKey) -> EdgeInsets {
+  public func setScaledEdgeInsets(_ edgeInsets: ScaledEdgeInsets, for key: PropertyKey)
+    -> ScaledEdgeInsets {
     self.edgeInsets[key] = edgeInsets
     return edgeInsets
   }
 
   /**
-   Returns the `EdgeInsets` value that is mapped to a specific `PropertyKey`.
+   Returns the `ScaledEdgeInsets` value that is mapped to a specific `PropertyKey`.
 
    - parameter key: The `PropertyKey` (e.g. `LayoutConfig.FieldTextFieldInsetPadding`)
-   - parameter defaultValue: [Optional] If no `EdgeInsets` was found for `key`, this value is
+   - parameter defaultValue: [Optional] If no `ScaledEdgeInsets` was found for `key`, this value is
    automatically assigned to `key` and used instead.
-   - returns: The `key`'s value
+   - returns: The `key`'s value.
    */
   @inline(__always)
-  public func edgeInsets(for key: PropertyKey, defaultValue: EdgeInsets = EdgeInsets())
-    -> EdgeInsets
+  public func scaledEdgeInsets(
+    for key: PropertyKey, defaultValue: ScaledEdgeInsets = ScaledEdgeInsets.zero)
+    -> ScaledEdgeInsets
   {
-    return edgeInsets[key] ?? setEdgeInsets(defaultValue, for: key)
+    return edgeInsets[key] ?? setScaledEdgeInsets(defaultValue, for: key)
+  }
+
+  /**
+   Returns the `viewEdgeInsets` of the `ScaledEdgeInsets` value that is mapped to a specific
+   `PropertyKey`.
+
+   - parameter key: The `PropertyKey` (e.g. `LayoutConfig.FieldTextFieldInsetPadding`)
+   - parameter defaultValue: [Optional] If no `ScaledEdgeInsets` was found for `key`, this value is
+   automatically assigned to `key` and used instead.
+   - returns: The `viewEdgeInsets` of the mapped `ScaledEdgeInsets` value.
+   */
+  @inline(__always)
+  public func viewEdgeInsets(
+    for key: PropertyKey, defaultValue: ScaledEdgeInsets = ScaledEdgeInsets.zero) -> EdgeInsets
+  {
+    return edgeInsets[key]?.viewEdgeInsets
+      ?? setScaledEdgeInsets(defaultValue, for: key).viewEdgeInsets
+  }
+
+  /**
+   Returns the `workspaceEdgeInsets` of the `ScaledEdgeInsets` value that is mapped to a specific
+   `PropertyKey`.
+
+   - parameter key: The `PropertyKey` (e.g. `LayoutConfig.FieldTextFieldInsetPadding`)
+   - parameter defaultValue: [Optional] If no `ScaledEdgeInsets` was found for `key`, this value is
+   automatically assigned to `key` and used instead.
+   - returns: The `workspaceEdgeInsets` of the mapped `ScaledEdgeInsets` value.
+   */
+  @inline(__always)
+  public func workspaceEdgeInsets(
+    for key: PropertyKey, defaultValue: ScaledEdgeInsets = ScaledEdgeInsets.zero) -> EdgeInsets
+  {
+    return edgeInsets[key]?.workspaceEdgeInsets
+      ?? setScaledEdgeInsets(defaultValue, for: key).workspaceEdgeInsets
   }
 
   /**
@@ -428,7 +473,7 @@ open class LayoutConfig: NSObject {
    - returns: The mapped `Size` value.
    */
   @inline(__always)
-  public func size(for key: PropertyKey, defaultValue: Size = Size(0, 0)) -> Size {
+  public func size(for key: PropertyKey, defaultValue: Size = Size(width: 0, height: 0)) -> Size {
     return sizes[key] ?? setSize(defaultValue, for: key)
   }
 
@@ -441,7 +486,7 @@ open class LayoutConfig: NSObject {
    - returns: The `viewSize` of the mapped `Size` value.
    */
   @inline(__always)
-  public func viewSize(for key: PropertyKey, defaultValue: Size = Size(0, 0))
+  public func viewSize(for key: PropertyKey, defaultValue: Size = Size(width: 0, height: 0))
     -> CGSize
   {
     return size(for: key, defaultValue: defaultValue).viewSize
@@ -456,7 +501,7 @@ open class LayoutConfig: NSObject {
    - returns: The `workspaceSize` of the mapped `Size` value.
    */
   @inline(__always)
-  public func workspaceSize(for key: PropertyKey, defaultValue: Size = Size(0, 0))
+  public func workspaceSize(for key: PropertyKey, defaultValue: Size = Size(width: 0, height: 0))
     -> WorkspaceSize
   {
     return size(for: key, defaultValue: defaultValue).workspaceSize
@@ -591,6 +636,16 @@ open class LayoutConfig: NSObject {
       sizes[key] = size
     }
 
+    for (key, var scaledEdgeInsets) in edgeInsets {
+      let workspaceEdgeInsets = scaledEdgeInsets.workspaceEdgeInsets
+      scaledEdgeInsets.viewEdgeInsets =
+        EdgeInsets(top: engine.viewUnitFromWorkspaceUnit(workspaceEdgeInsets.top),
+                   leading: engine.viewUnitFromWorkspaceUnit(workspaceEdgeInsets.leading),
+                   bottom: engine.viewUnitFromWorkspaceUnit(workspaceEdgeInsets.bottom),
+                   trailing: engine.viewUnitFromWorkspaceUnit(workspaceEdgeInsets.trailing))
+      edgeInsets[key] = scaledEdgeInsets
+    }
+
     for (_, scaledFont) in _fonts {
       scaledFont.font = scaledFont.creator(_scale)
       scaledFont.popoverFont = scaledFont.creator(_popoverScale)
@@ -614,5 +669,14 @@ extension LayoutConfig {
       self.font = creator(fontScale)
       self.popoverFont = creator(popoverFontScale)
     }
+  }
+}
+
+extension LayoutConfigEdgeInsets {
+  // MARK: - LayoutConfigEdgeInsets Extensions
+
+  /// Returns a `LayoutConfigEdgeInsets` where all values are zeroed out.
+  static var zero: LayoutConfigEdgeInsets {
+    return LayoutConfigEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
   }
 }

--- a/Sources/Layout/MutatorIfElseLayout.swift
+++ b/Sources/Layout/MutatorIfElseLayout.swift
@@ -52,7 +52,7 @@ public class MutatorIfElseLayout : MutatorLayout {
 
   public override func performLayout(includeChildren: Bool) {
     // Inside a block, this mutator is the size of a settings button
-    self.contentSize = WorkspaceSize(width: 32, height: 32)
+    self.contentSize = config.workspaceSize(for: LayoutConfig.MutatorButtonSize)
   }
 
   public override func performMutation() throws {

--- a/Sources/Layout/MutatorProcedureDefinitionLayout.swift
+++ b/Sources/Layout/MutatorProcedureDefinitionLayout.swift
@@ -62,7 +62,7 @@ public class MutatorProcedureDefinitionLayout : MutatorLayout {
 
   public override func performLayout(includeChildren: Bool) {
     // Inside a block, this mutator is the size of a settings button
-    self.contentSize = WorkspaceSize(width: 32, height: 32)
+    self.contentSize = config.workspaceSize(for: LayoutConfig.MutatorButtonSize)
   }
 
   public override func performMutation() throws {

--- a/Sources/ObjC/BKYLayoutConfigStructs.h
+++ b/Sources/ObjC/BKYLayoutConfigStructs.h
@@ -14,6 +14,7 @@
  */
 
 #import <CoreGraphics/CoreGraphics.h>
+#import "BKYEdgeInsets.h"
 #import "BKYWorkspaceUnits.h"
 
 // MARK: - BKYLayoutConfigUnit
@@ -62,4 +63,32 @@ typedef struct BKYLayoutConfigSize BKYLayoutConfigSize;
  `workspaceSize`.
  */
 BKYLayoutConfigSize BKYLayoutConfigSizeMake(CGFloat workspaceWidth, CGFloat workspaceHeight)
-  CF_SWIFT_NAME(LayoutConfigSize.init(_:_:));
+  CF_SWIFT_NAME(LayoutConfigSize.init(width:height:));
+
+// MARK: - BKYLayoutConfigEdgeInsets
+
+/// Struct for representing an EdgeInsets value (i.e. width/height) in both the Workspace coordinate
+/// system and UIView coordinate system.
+struct BKYLayoutConfigEdgeInsets {
+  /// The size value specified in the Workspace coordinate system
+  BKYEdgeInsets workspaceEdgeInsets;
+  /// The size value specified in the UIView coordinate system. This value is automatically derived
+  /// from `workspaceUnit` and should not be modified directly.
+  BKYEdgeInsets viewEdgeInsets;
+} CF_SWIFT_NAME(LayoutConfigEdgeInsets);
+typedef struct BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsets;
+
+/**
+ Creates a `BKYLayoutConfigEdgeInsets`, where `workspaceEdgeInsets` is initialized with
+ given edge insets.
+
+ @param top The top value to use for `workspaceEdgeInsets`.
+ @param leading The leading value to use for `workspaceEdgeInsets`.
+ @param bottom The bottom value to use for `workspaceEdgeInsets`.
+ @param trailing The trailing value to use for `workspaceEdgeInsets`.
+ @note `viewEdgeInsets` is automatically initialized to the correct value based on the generated
+ `workspaceEdgeInsets`.
+ */
+BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsetsMake(
+  CGFloat top, CGFloat leading, CGFloat bottom, CGFloat trailing)
+  CF_SWIFT_NAME(LayoutConfigEdgeInsets.init(top:leading:bottom:trailing:));

--- a/Sources/ObjC/BKYLayoutConfigStructs.m
+++ b/Sources/ObjC/BKYLayoutConfigStructs.m
@@ -32,3 +32,13 @@ BKYLayoutConfigSize BKYLayoutConfigSizeMake(CGFloat workspaceWidth, CGFloat work
   size.viewSize = CGSizeMake(workspaceWidth, workspaceHeight);
   return size;
 }
+
+// MARK: - BKYLayoutConfigEdgeInsets
+
+BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsetsMake(
+  CGFloat top, CGFloat leading, CGFloat bottom, CGFloat trailing) {
+  BKYLayoutConfigEdgeInsets edgeInsets;
+  edgeInsets.workspaceEdgeInsets = BKYEdgeInsetsMake(top, leading, bottom, trailing);
+  edgeInsets.viewEdgeInsets = BKYEdgeInsetsMake(top, leading, bottom, trailing);
+  return edgeInsets;
+}

--- a/Sources/UI/Views/Default/DefaultBlockView.swift
+++ b/Sources/UI/Views/Default/DefaultBlockView.swift
@@ -45,6 +45,7 @@ public final class DefaultBlockView: BlockView {
 
     // Add background layer
     self.layer.addSublayer(_backgroundLayer)
+    _backgroundLayer.zPosition = -1 // Ensure it's drawn behind everything.
   }
 
   /**
@@ -168,6 +169,12 @@ public final class DefaultBlockView: BlockView {
           layout.config.double(for: LayoutConfig.ViewAnimationDuration)
         backgroundLayer.setBezierPath(self.blockBackgroundBezierPath(), animated: animated)
         backgroundLayer.frame = self.bounds
+
+        if layout.highlighted {
+          // If this block is highlighted, bring it to the top so its highlight layer doesn't get
+          // covered by other sibling blocks.
+          self.superview?.bringSubview(toFront: self)
+        }
       }
 
       if flags.intersectsWith(
@@ -178,6 +185,10 @@ public final class DefaultBlockView: BlockView {
         // Update highlight
         if let path = self.blockHighlightBezierPath() {
           self.addHighlightLayer(withPath: path, animated: animated)
+
+          // Bring this block to the top so its connection highlight doesn't get covered by
+          // sibling blocks.
+          self.superview?.bringSubview(toFront: self)
         } else {
           self.removeHighlightLayer()
         }

--- a/Sources/UI/Views/FieldAngleView.swift
+++ b/Sources/UI/Views/FieldAngleView.swift
@@ -78,7 +78,7 @@ open class FieldAngleView: FieldView {
         textField.textColor =
           fieldAngleLayout.config.color(for: LayoutConfig.FieldEditableTextColor)
         textField.insetPadding =
-          fieldAngleLayout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+          fieldAngleLayout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
       }
     }
   }
@@ -137,7 +137,7 @@ extension FieldAngleView: FieldLayoutMeasurer {
       return CGSize.zero
     }
 
-    let textPadding = layout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+    let textPadding = layout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
     let maxWidth = layout.config.viewUnit(for: LayoutConfig.FieldTextFieldMaximumWidth)
     // Use a minimum size that can at least accomodate 3 digits and °. This is to help ensure that
     //  the angle picker popover doesn't ever accidentally obstruct the view of the text field
@@ -154,6 +154,8 @@ extension FieldAngleView: FieldLayoutMeasurer {
     measureSize.height += textPadding.top + textPadding.bottom
     measureSize.width =
       min(measureSize.width + textPadding.leading + textPadding.trailing, maxWidth)
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
     return measureSize
   }
 }

--- a/Sources/UI/Views/FieldColorView.swift
+++ b/Sources/UI/Views/FieldColorView.swift
@@ -106,7 +106,9 @@ extension FieldColorView: FieldLayoutMeasurer {
       return CGSize.zero
     }
 
-    return layout.config.viewSize(for: LayoutConfig.FieldColorButtonSize)
+    var size = layout.config.viewSize(for: LayoutConfig.FieldColorButtonSize)
+    size.height = max(size.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
+    return size
   }
 }
 

--- a/Sources/UI/Views/FieldDateView.swift
+++ b/Sources/UI/Views/FieldDateView.swift
@@ -101,7 +101,7 @@ open class FieldDateView: FieldView {
         textField.font = fieldDateLayout.config.font(for: LayoutConfig.GlobalFont)
         textField.textColor = fieldDateLayout.config.color(for: LayoutConfig.FieldEditableTextColor)
         textField.insetPadding =
-          fieldDateLayout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+          fieldDateLayout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
       }
     }
   }
@@ -154,12 +154,14 @@ extension FieldDateView: FieldLayoutMeasurer {
       return CGSize.zero
     }
 
-    let textPadding = layout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+    let textPadding = layout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
     let text = fieldDateLayout.textValue
     let font = layout.config.font(for: LayoutConfig.GlobalFont)
     var measureSize = text.bky_singleLineSize(forFont: font)
     measureSize.height += textPadding.top + textPadding.bottom
     measureSize.width += textPadding.leading + textPadding.trailing
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
     return measureSize
   }
 }

--- a/Sources/UI/Views/FieldDropdownView.swift
+++ b/Sources/UI/Views/FieldDropdownView.swift
@@ -112,10 +112,13 @@ extension FieldDropdownView: FieldLayoutMeasurer {
     let scale = fieldDropdownLayout.engine.scale
     let dropDownArrowImageSize = CGSize(width: size.width * scale, height: size.height * scale)
 
-    return DropdownView.measureSize(
+    var measureSize = DropdownView.measureSize(
       text: measureText, dropDownArrowImageSize: dropDownArrowImageSize,
       textFont: font, borderWidth: borderWidth, horizontalSpacing: xSpacing,
       verticalSpacing: ySpacing)
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
+    return measureSize
   }
 }
 

--- a/Sources/UI/Views/FieldInputView.swift
+++ b/Sources/UI/Views/FieldInputView.swift
@@ -85,7 +85,7 @@ open class FieldInputView: FieldView {
         textField.textColor =
           fieldInputLayout.config.color(for: LayoutConfig.FieldEditableTextColor)
         textField.insetPadding =
-          fieldInputLayout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+          fieldInputLayout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
       }
     }
   }
@@ -136,7 +136,7 @@ extension FieldInputView: FieldLayoutMeasurer {
       return CGSize.zero
     }
 
-    let textPadding = layout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+    let textPadding = layout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
     let maxWidth = layout.config.viewUnit(for: LayoutConfig.FieldTextFieldMaximumWidth)
     let measureText = fieldInputLayout.currentTextValue + " "
     let font = fieldInputLayout.config.font(for: LayoutConfig.GlobalFont)
@@ -144,6 +144,8 @@ extension FieldInputView: FieldLayoutMeasurer {
     measureSize.height += textPadding.top + textPadding.bottom
     measureSize.width =
       min(measureSize.width + textPadding.leading + textPadding.trailing, maxWidth)
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
     return measureSize
   }
 }

--- a/Sources/UI/Views/FieldLabelView.swift
+++ b/Sources/UI/Views/FieldLabelView.swift
@@ -91,6 +91,8 @@ extension FieldLabelView: FieldLayoutMeasurer {
     }
 
     let font = layout.config.font(for: LayoutConfig.GlobalFont)
-    return fieldLabelLayout.text.bky_singleLineSize(forFont: font)
+    var size = fieldLabelLayout.text.bky_singleLineSize(forFont: font)
+    size.height = max(size.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
+    return size
   }
 }

--- a/Sources/UI/Views/FieldNumberView.swift
+++ b/Sources/UI/Views/FieldNumberView.swift
@@ -80,7 +80,7 @@ open class FieldNumberView: FieldView {
         textField.font = layout.config.font(for: LayoutConfig.GlobalFont)
         textField.textColor = layout.config.color(for: LayoutConfig.FieldEditableTextColor)
         textField.insetPadding =
-          layout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+          layout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
       }
     }
   }
@@ -122,7 +122,7 @@ extension FieldNumberView: FieldLayoutMeasurer {
       return CGSize.zero
     }
 
-    let textPadding = layout.config.edgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
+    let textPadding = layout.config.viewEdgeInsets(for: LayoutConfig.FieldTextFieldInsetPadding)
     let maxWidth = layout.config.viewUnit(for: LayoutConfig.FieldTextFieldMaximumWidth)
     let measureText = fieldNumberLayout.currentTextValue + " "
     let font = layout.config.font(for: LayoutConfig.GlobalFont)
@@ -130,6 +130,8 @@ extension FieldNumberView: FieldLayoutMeasurer {
     measureSize.height = measureSize.height + textPadding.top + textPadding.bottom
     measureSize.width =
       min(measureSize.width + textPadding.leading + textPadding.trailing, maxWidth)
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
     return measureSize
   }
 }

--- a/Sources/UI/Views/FieldVariableView.swift
+++ b/Sources/UI/Views/FieldVariableView.swift
@@ -112,10 +112,13 @@ extension FieldVariableView: FieldLayoutMeasurer {
     let scale = fieldVariableLayout.engine.scale
     let dropDownArrowImageSize = CGSize(width: size.width * scale, height: size.height * scale)
 
-    return DropdownView.measureSize(
+    var measureSize = DropdownView.measureSize(
       text: measureText, dropDownArrowImageSize: dropDownArrowImageSize,
       textFont: font, borderWidth: borderWidth, horizontalSpacing: xSpacing,
       verticalSpacing: ySpacing)
+    measureSize.height =
+      max(measureSize.height, layout.config.viewUnit(for: LayoutConfig.FieldMinimumHeight))
+    return measureSize
   }
 }
 

--- a/Sources/UI/Views/InputView.swift
+++ b/Sources/UI/Views/InputView.swift
@@ -61,6 +61,10 @@ open class InputView: LayoutView {
         // Update the view frame
         self.frame = layout.viewFrame
       }
+
+      // Force the input view to always be drawn behind sibling views (which could be other
+      // blocks).
+      self.superview?.sendSubview(toBack: self)
     }
   }
 

--- a/Sources/UI/Views/MutatorIfElseView.swift
+++ b/Sources/UI/Views/MutatorIfElseView.swift
@@ -75,6 +75,10 @@ open class MutatorIfElseView: LayoutView {
       if flags.intersectsWith([Layout.Flag_NeedsDisplay, Layout.Flag_UpdateViewFrame]) {
         // Update the view frame
         self.frame = layout.viewFrame
+
+        // Force the mutator view to always be drawn behind sibling views (which could be other
+        // blocks).
+        self.superview?.sendSubview(toBack: self)
       }
 
       let topPadding = layout.engine.viewUnitFromWorkspaceUnit(4)

--- a/Sources/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Sources/UI/Views/MutatorProcedureDefinitionView.swift
@@ -76,6 +76,10 @@ open class MutatorProcedureDefinitionView: LayoutView {
       if flags.intersectsWith([Layout.Flag_NeedsDisplay, Layout.Flag_UpdateViewFrame]) {
         // Update the view frame
         self.frame = layout.viewFrame
+
+        // Force the mutator view to always be drawn behind sibling views (which could be other
+        // blocks).
+        self.superview?.sendSubview(toBack: self)
       }
 
       let topPadding = layout.engine.viewUnitFromWorkspaceUnit(4)


### PR DESCRIPTION
- Fixed scaling bug with EdgeInsets by adding a scaled version to LayoutConfig
- Removed highlighting of block that's being dragged
- Minor tweaks to block rendering

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/418)
<!-- Reviewable:end -->
