### PR TITLE
- Fixes connection highlighting so it appears after animations have c...

### DIFF
--- a/Sources/Common/ImageLoader.swift
+++ b/Sources/Common/ImageLoader.swift
@@ -27,17 +27,29 @@ public final class ImageLoader: NSObject {
 
    - parameter imageName: The name of the image in a bundle's asset catalog.
    - parameter anyClass: The class that is requesting the image.
+   - parameter flipForRTL: `true` if the image should be flipped on the Y-axis for RTL purposes.
+   `false` if the image should not be flipped.
    - returns: The image, either from the main application bundle or the default bundle for the
    given class.
    - note: Images are loaded via UIImage(imageNamed:), which means they are cached in the system
    by default after they are loaded.
    */
-  public class func loadImage(named imageName: String, forClass anyClass: AnyClass) -> UIImage? {
+  public class func loadImage(
+    named imageName: String, forClass anyClass: AnyClass, flipForRTL: Bool = false) -> UIImage? {
+    var returnImage: UIImage?
     if let image = UIImage(named: imageName) {
-      return image
+      returnImage = image
     } else {
       let bundle = Bundle(for: anyClass)
-      return UIImage(named: imageName, in: bundle, compatibleWith: nil)
+      returnImage = UIImage(named: imageName, in: bundle, compatibleWith: nil)
+    }
+
+    if flipForRTL,
+      let cgImage = returnImage?.cgImage,
+      let scale = returnImage?.scale {
+      return UIImage(cgImage: cgImage, scale: scale, orientation: .upMirrored)
+    } else {
+      return returnImage
     }
   }
 }

--- a/Sources/Layout/Default/DefaultLayoutConfig.swift
+++ b/Sources/Layout/Default/DefaultLayoutConfig.swift
@@ -30,6 +30,9 @@ open class DefaultLayoutConfig: LayoutConfig {
   /// [`Unit`] Width of a highlighted line stroke for a block
   public static let BlockLineWidthHighlight = LayoutConfig.newPropertyKey()
 
+  /// [`Unit`] Width of the line stroke for a highlighted connection.
+  public static let BlockConnectionLineWidthHighlight = LayoutConfig.newPropertyKey()
+
   /// [`Unit`] Height of a horizontal puzzle tab
   public static let PuzzleTabHeight = LayoutConfig.newPropertyKey()
 
@@ -63,6 +66,9 @@ open class DefaultLayoutConfig: LayoutConfig {
 
   /// [`UIColor`] The stroke color to use when rendering a disabled block
   public static let BlockStrokeDisabledColor = LayoutConfig.newPropertyKey()
+
+  /// [`UIColor`] The stroke color to use when rendering a highlighted connection on a block.
+  public static let BlockConnectionHighlightStrokeColor = LayoutConfig.newPropertyKey()
 
   /// [`UIColor`] The fill color to use when rendering a disabled block
   public static let BlockFillDisabledColor = LayoutConfig.newPropertyKey()
@@ -107,6 +113,7 @@ open class DefaultLayoutConfig: LayoutConfig {
     setUnit(Unit(4), for: DefaultLayoutConfig.BlockCornerRadius)
     setUnit(Unit(1), for: DefaultLayoutConfig.BlockLineWidthRegular)
     setUnit(Unit(3), for: DefaultLayoutConfig.BlockLineWidthHighlight)
+    setUnit(Unit(3), for: DefaultLayoutConfig.BlockConnectionLineWidthHighlight)
     setUnit(Unit(20), for: DefaultLayoutConfig.PuzzleTabHeight)
     setUnit(Unit(8), for: DefaultLayoutConfig.PuzzleTabWidth)
     setUnit(Unit(16), for: DefaultLayoutConfig.NotchXOffset)
@@ -118,6 +125,7 @@ open class DefaultLayoutConfig: LayoutConfig {
 
     setColor(UIColor.darkGray, for: DefaultLayoutConfig.BlockStrokeDefaultColor)
     setColor(UIColor.blue, for: DefaultLayoutConfig.BlockStrokeHighlightColor)
+    setColor(ColorHelper.makeColor(rgb: "304FFE"), for: DefaultLayoutConfig.BlockConnectionHighlightStrokeColor)
     setColor(ColorHelper.makeColor(rgb: "555555"),
              for: DefaultLayoutConfig.BlockStrokeDisabledColor)
     setColor(ColorHelper.makeColor(rgb: "dddddd"),

--- a/Sources/Layout/LayoutConfig.swift
+++ b/Sources/Layout/LayoutConfig.swift
@@ -671,12 +671,3 @@ extension LayoutConfig {
     }
   }
 }
-
-extension LayoutConfigEdgeInsets {
-  // MARK: - LayoutConfigEdgeInsets Extensions
-
-  /// Returns a `LayoutConfigEdgeInsets` where all values are zeroed out.
-  static var zero: LayoutConfigEdgeInsets {
-    return LayoutConfigEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-  }
-}

--- a/Sources/ObjC/BKYLayoutConfigStructs.h
+++ b/Sources/ObjC/BKYLayoutConfigStructs.h
@@ -92,3 +92,9 @@ typedef struct BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsets;
 BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsetsMake(
   CGFloat top, CGFloat leading, CGFloat bottom, CGFloat trailing)
   CF_SWIFT_NAME(LayoutConfigEdgeInsets.init(top:leading:bottom:trailing:));
+
+/**
+ Creates a `BKYLayoutConfigEdgeInsets`, where both workspace and view edge inset values are set to zero.
+ */
+extern BKYLayoutConfigEdgeInsets const BKYLayoutConfigEdgeInsetsZero
+  CF_SWIFT_NAME(LayoutConfigEdgeInsets.zero);

--- a/Sources/ObjC/BKYLayoutConfigStructs.m
+++ b/Sources/ObjC/BKYLayoutConfigStructs.m
@@ -42,3 +42,8 @@ BKYLayoutConfigEdgeInsets BKYLayoutConfigEdgeInsetsMake(
   edgeInsets.viewEdgeInsets = BKYEdgeInsetsMake(top, leading, bottom, trailing);
   return edgeInsets;
 }
+
+BKYLayoutConfigEdgeInsets const BKYLayoutConfigEdgeInsetsZero = {
+  .workspaceEdgeInsets = { .top = 0, .leading = 0, .bottom = 0, .trailing = 0 },
+  .viewEdgeInsets = { .top = 0, .leading = 0, .bottom = 0, .trailing = 0 }
+};

--- a/Sources/UI/View Controllers/WorkbenchViewController.swift
+++ b/Sources/UI/View Controllers/WorkbenchViewController.swift
@@ -128,7 +128,8 @@ open class WorkbenchViewController: UIViewController {
   /// The undo button
   open fileprivate(set) lazy var undoButton: UIButton = {
     let undoButton = UIButton(type: .custom)
-    if let image = ImageLoader.loadImage(named: "undo", forClass: WorkbenchViewController.self) {
+    if let image = ImageLoader.loadImage(
+      named: "undo", forClass: WorkbenchViewController.self, flipForRTL: self.engine.rtl) {
       undoButton.setImage(image, for: .normal)
       undoButton.contentMode = .center
     }
@@ -140,7 +141,8 @@ open class WorkbenchViewController: UIViewController {
   /// The redo button
   open fileprivate(set) lazy var redoButton: UIButton = {
     let redoButton = UIButton(type: .custom)
-    if let image = ImageLoader.loadImage(named: "redo", forClass: WorkbenchViewController.self) {
+    if let image = ImageLoader.loadImage(
+      named: "redo", forClass: WorkbenchViewController.self, flipForRTL: self.engine.rtl) {
       redoButton.setImage(image, for: .normal)
       redoButton.contentMode = .center
     }

--- a/Sources/UI/Views/Default/DefaultBlockView.swift
+++ b/Sources/UI/Views/Default/DefaultBlockView.swift
@@ -509,7 +509,8 @@ public final class DefaultBlockView: BlockView {
               inputLayout.inlineConnectorSize.height - cornerRadius
           } else {
             lineStartY = inputLayout.relativePosition.y + cornerRadius
-            lineEndY = inputLayout.relativePosition.y + inputLayout.contentSize.height - cornerRadius
+            lineEndY =
+              inputLayout.relativePosition.y + inputLayout.contentSize.height - cornerRadius
           }
         } else if connection.sourceBlock == layout.block && connection.type == .outputValue {
           // Use block size to figure out line extensions

--- a/Sources/UI/Views/Default/DefaultBlockView.swift
+++ b/Sources/UI/Views/Default/DefaultBlockView.swift
@@ -32,10 +32,26 @@ public final class DefaultBlockView: BlockView {
   fileprivate var _disableLayerChangeAnimations: Bool = true
 
   /// Layer for rendering the block's background
-  fileprivate let _backgroundLayer = BezierPathLayer()
+  fileprivate let _backgroundLayer: BezierPathLayer = {
+    var layer = BezierPathLayer()
+    layer.lineCap = kCALineCapRound
+    // Set z-position so it renders below most other layers (all layers default to 0).
+    layer.zPosition = -1
+    return layer
+  }()
 
   /// Layer for rendering the block's highlight overlay
-  fileprivate var _highlightLayer: BezierPathLayer?
+  fileprivate let _highlightLayer: BezierPathLayer = {
+    var layer = BezierPathLayer()
+    layer.lineCap = kCALineCapRound
+    layer.fillColor = nil
+    // Set z-position so it renders above most other layers (all layers default to 0).
+    layer.zPosition = 1
+    return layer
+  }()
+
+  /// Number of animations that are currently running `refreshView(forFlags:animated:)`.
+  private var runningRefreshViewCodeCounter = 0
 
   // MARK: - Initializers
 
@@ -43,9 +59,9 @@ public final class DefaultBlockView: BlockView {
   public required init() {
     super.init()
 
-    // Add background layer
-    self.layer.addSublayer(_backgroundLayer)
-    _backgroundLayer.zPosition = -1 // Ensure it's drawn behind everything.
+    // Add background/highlight layers
+    layer.addSublayer(_backgroundLayer)
+    layer.addSublayer(_highlightLayer)
   }
 
   /**
@@ -92,7 +108,10 @@ public final class DefaultBlockView: BlockView {
       return
     }
 
-    runAnimatableCode(animated) {
+    runAnimatableCode(animated, code: {
+      // Increment the number of blocks that are running this animation part of the code.
+      self.runningRefreshViewCodeCounter += 1
+
       // Note: This code isn't wrapped inside an explicit CATransaction since that will render the
       // changes immediately. The problem with this is that all other views use the implicit
       // CATransaction that is created for every run loop. If we use a different CATransaction,
@@ -177,21 +196,13 @@ public final class DefaultBlockView: BlockView {
         }
       }
 
-      if flags.intersectsWith(
-        [BlockLayout.Flag_NeedsDisplay,
+      if flags.intersectsWith([
+          BlockLayout.Flag_NeedsDisplay,
           BlockLayout.Flag_UpdateHighlight,
           BlockLayout.Flag_UpdateConnectionHighlight]) || forceBezierPathRedraw
       {
-        // Update highlight
-        if let path = self.blockHighlightBezierPath() {
-          self.addHighlightLayer(withPath: path, animated: animated)
-
-          // Bring this block to the top so its connection highlight doesn't get covered by
-          // sibling blocks.
-          self.superview?.bringSubview(toFront: self)
-        } else {
-          self.removeHighlightLayer()
-        }
+        // Remove connection highlights (they will be potentially re-added in the completion block).
+        self._highlightLayer.setBezierPath(nil, animated: false)
       }
 
       // Restore disabled actions to previous value
@@ -199,7 +210,28 @@ public final class DefaultBlockView: BlockView {
 
       // Re-enable layer animations for any future changes
       self._disableLayerChangeAnimations = false
-    }
+    }, completion: { _ in
+      // Decrement the number of blocks that are running the animatable part of the code.
+      self.runningRefreshViewCodeCounter -= 1
+
+      // Once all animatable code blocks have finished running, re-add connection highlights (if necessary).
+      if self.runningRefreshViewCodeCounter == 0,
+        let path = self.blockHighlightBezierPath() {
+        // Configure highlight layer
+        let highlightLayer = self._highlightLayer
+        highlightLayer.lineWidth =
+          layout.config.viewUnit(for: DefaultLayoutConfig.BlockConnectionLineWidthHighlight)
+        highlightLayer.strokeColor =
+          layout.config.color(for: DefaultLayoutConfig.BlockConnectionHighlightStrokeColor)?.cgColor
+          ?? UIColor.clear.cgColor
+        highlightLayer.setBezierPath(path, animated: false)
+        highlightLayer.frame = self.bounds
+
+        // Bring this block to the top so its connection highlight doesn't get covered by
+        // sibling blocks.
+        self.superview?.bringSubview(toFront: self)
+      }
+    })
   }
 
   open override func prepareForReuse() {
@@ -210,46 +242,10 @@ public final class DefaultBlockView: BlockView {
     _disableLayerChangeAnimations = true
 
     _backgroundLayer.setBezierPath(nil, animated: false)
-    removeHighlightLayer()
+    _highlightLayer.setBezierPath(nil, animated: false)
   }
 
   // MARK: - Private
-
-  fileprivate func addHighlightLayer(withPath path: UIBezierPath, animated: Bool) {
-    guard let layout = self.defaultBlockLayout else {
-      return
-    }
-
-    // TODO(#170): Connection highlights need to be animated into position. Currently, they always
-    // just appear in their final destination position.
-
-    // Use existing _highlightLayer or create a new one
-    let highlightLayer = _highlightLayer ?? BezierPathLayer()
-    layer.addSublayer(highlightLayer)
-    _highlightLayer = highlightLayer
-
-    // Configure highlight
-    highlightLayer.lineWidth =
-      layout.config.viewUnit(for: DefaultLayoutConfig.BlockLineWidthHighlight)
-    highlightLayer.strokeColor =
-      layout.config.color(for: DefaultLayoutConfig.BlockStrokeHighlightColor)?.cgColor ??
-      UIColor.clear.cgColor
-    highlightLayer.fillColor = nil
-    // TODO(#41): The highlight view frame needs to be larger than this view since it uses a
-    // larger line width
-    // Set the zPosition to 1 so it's higher than most other layers (all layers default to 0)
-    highlightLayer.zPosition = 1
-    highlightLayer.animationDuration = layout.config.double(for: LayoutConfig.ViewAnimationDuration)
-    highlightLayer.setBezierPath(path, animated: animated)
-    highlightLayer.frame = bounds
-  }
-
-  fileprivate func removeHighlightLayer() {
-    if let highlightLayer = _highlightLayer {
-      highlightLayer.removeFromSuperlayer()
-      _highlightLayer = nil
-    }
-  }
 
   fileprivate func blockBackgroundBezierPath() -> UIBezierPath? {
     guard let layout = self.defaultBlockLayout else {
@@ -456,7 +452,6 @@ public final class DefaultBlockView: BlockView {
         // Finish left edge
         path.addLineTo(x: 0, y: -(puzzleLineExtension - cornerRadius), relative: true)
         PathHelper.addCorner(.topLeft, toPath: path, radius: cornerRadius, clockwise: true)
-
       }
     }
 
@@ -481,6 +476,9 @@ public final class DefaultBlockView: BlockView {
     let notchHeight = layout.config.workspaceUnit(for: DefaultLayoutConfig.NotchHeight)
     let puzzleTabWidth = layout.config.workspaceUnit(for: DefaultLayoutConfig.PuzzleTabWidth)
     let puzzleTabHeight = layout.config.workspaceUnit(for: DefaultLayoutConfig.PuzzleTabHeight)
+    let cornerRadius = layout.config.workspaceUnit(for: DefaultLayoutConfig.BlockCornerRadius)
+    let xLeftEdgeOffset = layout.background.leadingEdgeXOffset
+    let topEdgeOffset = layout.background.leadingEdgeYOffset
 
     // Build path for each highlighted connection
     let path = WorkspaceBezierPath(engine: layout.engine)
@@ -495,22 +493,81 @@ public final class DefaultBlockView: BlockView {
       // Highlight specific connection
       switch connection.type {
       case .inputValue, .outputValue:
-        // The connection point is set to the apex of the puzzle tab's curve. Move the point before
-        // drawing it.
-        path.move(to: connectionRelativePosition +
-          WorkspacePoint(x: puzzleTabWidth, y: -puzzleTabHeight / 2),
-          relative: false)
-        PathHelper.addPuzzleTab(toPath: path, drawTopToBottom: true,
-          puzzleTabWidth: puzzleTabWidth, puzzleTabHeight: puzzleTabHeight)
-        break
+        // The connection is in the shape of the puzzle tab. Figure out the starting draw position.
+        let connectionStartPosition = WorkspacePoint(
+          x: connectionRelativePosition.x + puzzleTabWidth,
+          y: connectionRelativePosition.y - puzzleTabHeight / 2)
+        var lineStartY = connectionStartPosition.y
+        var lineEndY = connectionStartPosition.y + puzzleTabHeight
+
+        // Figure out if there can be line extensions drawn on the top and bottom of the puzzle tab.
+        if connection.type == .inputValue,
+          let inputLayout = connection.sourceInput?.layout as? DefaultInputLayout {
+          if layout.inputsInline {
+            lineStartY = inputLayout.inlineConnectorPosition.y + cornerRadius
+            lineEndY = inputLayout.inlineConnectorPosition.y +
+              inputLayout.inlineConnectorSize.height - cornerRadius
+          } else {
+            lineStartY = inputLayout.relativePosition.y + cornerRadius
+            lineEndY = inputLayout.relativePosition.y + inputLayout.contentSize.height - cornerRadius
+          }
+        } else if connection.sourceBlock == layout.block && connection.type == .outputValue {
+          // Use block size to figure out line extensions
+          lineStartY = topEdgeOffset + cornerRadius
+          lineEndY = topEdgeOffset + layout.contentSize.height - cornerRadius
+        }
+
+        // Draw top line extension, puzzle tab, and then bottom line extension.
+        path.move(to: WorkspacePoint(x: connectionStartPosition.x, y: lineStartY), relative: false)
+        path.addLine(to: connectionStartPosition, relative: false)
+        PathHelper.addPuzzleTab(
+          toPath: path,
+          drawTopToBottom: true,
+          puzzleTabWidth: puzzleTabWidth,
+          puzzleTabHeight: puzzleTabHeight)
+        path.addLineTo(x: path.currentWorkspacePoint.x, y: lineEndY, relative: false)
+
       case .previousStatement, .nextStatement:
-        // The connection point is set to the bottom of the notch. Move the point before drawing it.
-        path.move(to: connectionRelativePosition -
-          WorkspacePoint(x: notchWidth / 2, y: notchHeight),
-          relative: false)
+        // The connection is in the shape of a notch. Figure out the starting draw position.
+        let connectionStartPosition = WorkspacePoint(
+          x: connectionRelativePosition.x - notchWidth / 2,
+          y: connectionRelativePosition.y - notchHeight)
+        var lineStartX = connectionStartPosition.x
+        var lineEndX = connectionStartPosition.x + puzzleTabWidth
+
+        // Figure out if there can be line extensions drawn to the left and right of the notch.
+        if let inputLayout = connection.sourceInput?.layout as? DefaultInputLayout,
+          let rowIndex = layout.background.rows.index(where: { $0.layouts.contains(inputLayout) }) {
+          // Use input row information to figure out line extensions
+          let backgroundRow = layout.background.rows[rowIndex]
+
+          lineStartX = xLeftEdgeOffset + backgroundRow.statementIndent + cornerRadius
+          lineEndX = backgroundRow.rightEdge - cornerRadius
+
+          if connection.type == .nextStatement && rowIndex > 0 {
+            // For next statements, their top edge is the maximum of the previous row's right edge
+            // and its own row's right edge.
+            lineEndX = max(lineEndX, layout.background.rows[rowIndex - 1].rightEdge - cornerRadius)
+          }
+        } else if connection.sourceBlock == layout.block {
+          // Use block information to figure out line extensions
+          lineStartX = xLeftEdgeOffset + cornerRadius
+
+          if connection.type == .previousStatement,
+            let firstBackgroundRow = layout.background.rows.first {
+            lineEndX = firstBackgroundRow.rightEdge - cornerRadius
+          } else if connection.type == .nextStatement,
+            let lastBackgroundRow = layout.background.rows.last {
+            lineEndX = lastBackgroundRow.rightEdge - cornerRadius
+          }
+        }
+
+        // Draw left line extension, notch, and then right line extension.
+        path.move(to: WorkspacePoint(x: lineStartX, y: connectionStartPosition.y), relative: false)
+        path.addLine(to: connectionStartPosition, relative: false)
         PathHelper.addNotch(
           toPath: path, drawLeftToRight: true, notchWidth: notchWidth, notchHeight: notchHeight)
-        break
+        path.addLineTo(x: lineEndX, y: path.currentWorkspacePoint.y, relative: false)
       }
     }
 

--- a/Sources/UI/Views/LayoutView.swift
+++ b/Sources/UI/Views/LayoutView.swift
@@ -113,6 +113,20 @@ open class LayoutView: UIView {
    - parameter code: The code block to run.
    */
   open func runAnimatableCode(_ animated: Bool, code: @escaping () -> Void) {
+    runAnimatableCode(animated, code: code, completion: nil)
+  }
+
+  /**
+   Runs a code block, allowing it to be run immediately or via a preset animation.
+
+   - parameter animated: Flag determining if the `code` should be animated.
+   - parameter code: The code block to run.
+   - parameter completion: The completion block to run after the code block has finished running.
+   This block has no return value and takes a single Boolean argument that indicates whether or not
+   the animations actually finished before the completion handler was called.
+  */
+  open func runAnimatableCode(
+    _ animated: Bool, code: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
     if animated {
       let duration = layout?.config.double(for: LayoutConfig.ViewAnimationDuration) ?? 0
       if duration > 0 {
@@ -121,13 +135,14 @@ open class LayoutView: UIView {
           delay: 0,
           options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut],
           animations: code,
-          completion: nil)
+          completion: completion)
 
         return
       }
     }
 
     code()
+    completion?(true)
   }
 }
 


### PR DESCRIPTION
...ompleted
- Extends connection highlighting to include the line edges
- Fixes undo/redo buttons not having their images flipped for RTL
- Fixes LayoutConfigEdgeInsets.zero so it can be included as a default param
 in method signatures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/422)
<!-- Reviewable:end -->
