### PR TITLE
Fixes bug where multi-touch dragging a connected shadow block would…

### DIFF
--- a/Sources/Common/ImageLoader.swift
+++ b/Sources/Common/ImageLoader.swift
@@ -27,29 +27,17 @@ public final class ImageLoader: NSObject {
 
    - parameter imageName: The name of the image in a bundle's asset catalog.
    - parameter anyClass: The class that is requesting the image.
-   - parameter flipForRTL: `true` if the image should be flipped on the Y-axis for RTL purposes.
-   `false` if the image should not be flipped.
    - returns: The image, either from the main application bundle or the default bundle for the
    given class.
    - note: Images are loaded via UIImage(imageNamed:), which means they are cached in the system
    by default after they are loaded.
    */
-  public class func loadImage(
-    named imageName: String, forClass anyClass: AnyClass, flipForRTL: Bool = false) -> UIImage? {
-    var returnImage: UIImage?
+  public class func loadImage(named imageName: String, forClass anyClass: AnyClass) -> UIImage? {
     if let image = UIImage(named: imageName) {
-      returnImage = image
+      return image
     } else {
       let bundle = Bundle(for: anyClass)
-      returnImage = UIImage(named: imageName, in: bundle, compatibleWith: nil)
-    }
-
-    if flipForRTL,
-      let cgImage = returnImage?.cgImage,
-      let scale = returnImage?.scale {
-      return UIImage(cgImage: cgImage, scale: scale, orientation: .upMirrored)
-    } else {
-      return returnImage
+      return UIImage(named: imageName, in: bundle, compatibleWith: nil)
     }
   }
 }

--- a/Sources/Common/UIView+Helper.swift
+++ b/Sources/Common/UIView+Helper.swift
@@ -50,4 +50,22 @@ extension UIView {
     return nil
   }
 
+  /**
+   Returns whether this view is a descendant of a given `UIView`.
+
+   - parameter: The `UIView` to check.
+   - returns: `true` if this view is a descendant of `otherView`. `false` otherwise.
+   */
+  internal final func bky_isDescendant(of otherView: UIView) -> Bool {
+    var parent = self.superview
+
+    while parent != nil {
+      if parent === otherView {
+        return true
+      }
+      parent = parent?.superview
+    }
+
+    return false
+  }
 }

--- a/Sources/Control/BlockBumper.swift
+++ b/Sources/Control/BlockBumper.swift
@@ -50,7 +50,8 @@ open class BlockBumper: NSObject {
     _ impingingConnection: Connection, awayFromConnection stationaryConnection: Connection)
   {
     guard let blockLayout = impingingConnection.sourceBlock?.layout,
-      let blockGroupLayout = blockLayout.rootBlockGroupLayout else {
+      let blockGroupLayout = blockLayout.rootBlockGroupLayout,
+      !blockGroupLayout.dragging else {
       return
     }
 

--- a/Sources/Control/Dragger.swift
+++ b/Sources/Control/Dragger.swift
@@ -215,6 +215,19 @@ public final class Dragger: NSObject {
     clearGestureData(forUUID: layout.uuid, moveConnectionsToGroup: nil)
   }
 
+  /**
+   Cancels all existing drags in the workspace.
+   */
+  public func cancelAllDrags() {
+    let drags = Array(_dragGestureData.values)
+
+    for drag in drags {
+      if let blockLayout = drag.blockLayout {
+        cancelDraggingBlockLayout(blockLayout)
+      }
+    }
+  }
+
   // MARK: - Private
 
   /**

--- a/Sources/UI/View Controllers/ToolboxCategoryViewController.swift
+++ b/Sources/UI/View Controllers/ToolboxCategoryViewController.swift
@@ -56,7 +56,7 @@ public final class ToolboxCategoryViewController: UIViewController {
     get { return self.workspaceViewController.delegate }
   }
   /// The scroll view from the toolbox workspace's view controller.
-  public var workspaceScrollView: UIScrollView {
+  public var workspaceScrollView: WorkspaceView.ScrollView {
     return workspaceViewController.workspaceView.scrollView
   }
 

--- a/Sources/UI/View Controllers/WorkbenchViewController.swift
+++ b/Sources/UI/View Controllers/WorkbenchViewController.swift
@@ -1726,18 +1726,9 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
 extension WorkbenchViewController: UIGestureRecognizerDelegate {
   public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
 
-    if workspaceViewController.workspaceView.scrollView.isDragging ||
-      workspaceViewController.workspaceView.scrollView.isDecelerating ||
-      workspaceViewController.workspaceView.scrollView.isZooming ||
-      workspaceViewController.workspaceView.scrollView.isZoomBouncing ||
-      toolboxCategoryViewController.workspaceScrollView.isDragging ||
-      toolboxCategoryViewController.workspaceScrollView.isDecelerating ||
-      toolboxCategoryViewController.workspaceScrollView.isZooming ||
-      toolboxCategoryViewController.workspaceScrollView.isZoomBouncing ||
-      trashCanViewController.workspaceView.scrollView.isDragging ||
-      trashCanViewController.workspaceView.scrollView.isDecelerating ||
-      trashCanViewController.workspaceView.scrollView.isZooming ||
-      trashCanViewController.workspaceView.scrollView.isZoomBouncing {
+    if workspaceViewController.workspaceView.scrollView.isInMotion ||
+      toolboxCategoryViewController.workspaceScrollView.isInMotion ||
+      trashCanViewController.workspaceView.scrollView.isInMotion {
       return false
     }
 

--- a/Sources/UI/View Controllers/WorkspaceViewController.swift
+++ b/Sources/UI/View Controllers/WorkspaceViewController.swift
@@ -195,9 +195,10 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
     -> Bool
   {
     guard !workspaceView.scrollView.isDragging && !workspaceView.scrollView.isDecelerating &&
+      !workspaceView.scrollView.isZooming && !workspaceView.scrollView.isZoomBouncing &&
       !(self.presentedViewController?.isBeingPresented ?? false) else
     {
-      // Don't present anything if the scroll view is being dragged or is decelerating, or if
+      // Don't present anything if the scroll view is being dragged, decelerating, zooming, or if
       // another view controller is being presented
       return false
     }

--- a/Sources/UI/View Controllers/WorkspaceViewController.swift
+++ b/Sources/UI/View Controllers/WorkspaceViewController.swift
@@ -194,12 +194,11 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
     requestedToPresentPopoverViewController viewController: UIViewController, fromView: UIView)
     -> Bool
   {
-    guard !workspaceView.scrollView.isDragging && !workspaceView.scrollView.isDecelerating &&
-      !workspaceView.scrollView.isZooming && !workspaceView.scrollView.isZoomBouncing &&
+    guard !workspaceView.scrollView.isInMotion &&
       !(self.presentedViewController?.isBeingPresented ?? false) else
     {
-      // Don't present anything if the scroll view is being dragged, decelerating, zooming, or if
-      // another view controller is being presented
+      // Don't present anything if the scroll view is in motion or if another view controller is
+      // being presented
       return false
     }
 

--- a/Sources/UI/Views/BlockGroupView.swift
+++ b/Sources/UI/Views/BlockGroupView.swift
@@ -16,6 +16,17 @@
 import Foundation
 
 /**
+ Protocol for events that occur on a `BlockGroupView`.
+ */
+@objc(BKYBlockGroupViewDelegate)
+protocol BlockGroupViewDelegate: class {
+  /**
+   Event that is called when a `BlockGroupView` has its `dragging` property.
+   */
+  func blockGroupViewDidUpdateDragging(_ blockGroupView: BlockGroupView)
+}
+
+/**
  View for rendering a `BlockGroupLayout`.
  */
 @objc(BKYBlockGroupView)
@@ -28,6 +39,9 @@ open class BlockGroupView: LayoutView, ZIndexedView {
     return layout as? BlockGroupLayout
   }
 
+  /// Delegate for listening to events that occur on this instance.
+  weak var delegate: BlockGroupViewDelegate?
+
   /// The z-index of the block group view
   public fileprivate(set) final var zIndex: UInt = 0 {
     didSet {
@@ -36,6 +50,15 @@ open class BlockGroupView: LayoutView, ZIndexedView {
           // Re-order this view within its parent BlockGroupView view
           superview.upsertView(self)
         }
+      }
+    }
+  }
+
+  /// Flag indicating if this view is being dragged.
+  public var dragging: Bool = false {
+    didSet {
+      if dragging != oldValue {
+        delegate?.blockGroupViewDidUpdateDragging(self)
       }
     }
   }
@@ -76,6 +99,8 @@ open class BlockGroupView: LayoutView, ZIndexedView {
     }
 
     if flags.intersectsWith([Layout.Flag_NeedsDisplay, BlockGroupLayout.Flag_UpdateDragging]) {
+      self.dragging = layout.dragging
+
       // Update the alpha interaction. This part isn't animated since it can look weird when
       // connecting new blocks into an existing block group that was previously highlighted before
       // (the new blocks will change from fully opaque to translucent, and then quickly animate

--- a/Sources/UI/Views/WorkspaceView.swift
+++ b/Sources/UI/Views/WorkspaceView.swift
@@ -685,6 +685,12 @@ extension WorkspaceView {
       return view
     }()
 
+    /// Flag indicating if this scroll view is zooming, zoom-bouncing, dragging, or decelerating.
+    /// - note: It does not indicate if this scroll view is currently tracking touches.
+    public var isInMotion: Bool {
+      return isDragging || isDecelerating || isZooming || isZoomBouncing
+    }
+
     // MARK: - Initializers
 
     /**

--- a/Sources/UI/Views/ZIndexedGroupView.swift
+++ b/Sources/UI/Views/ZIndexedGroupView.swift
@@ -50,7 +50,7 @@ public final class ZIndexedGroupView: UIView {
    - parameter event: The event requesting the hit test.
    */
   public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    for target in subviews.lazy.reversed() {
+    for target in subviews.lazy.reversed() { // Reversed to respect z-indexing.
       let pointForTargetView = target.convert(point, from: self)
 
       // If the touch is inside any child of this view, return the hit test for it.
@@ -61,8 +61,9 @@ public final class ZIndexedGroupView: UIView {
       }
     }
 
-    // If none of the children of this view have been hit, continue hit testing as usual.
-    return super.hitTest(point, with: event)
+    // If none of the subviews were hit tested, we don't consider this view as being hit test
+    // (since its just a transparent view).
+    return nil
   }
 
   // MARK: - Public


### PR DESCRIPTION
… mess up event grouping
- Changes WorkbenchViewController view to use a single pan gesture recognizer instead of 3
- Fixes block dragging so it occurs above the toolbox
- Fixes orientation of undo/redo buttons in RTL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/425)
<!-- Reviewable:end -->
