### PR TITLE
- Allows disabled blocks to be dragged on the workspace

### DIFF
--- a/Sources/Layout/BlockLayout.swift
+++ b/Sources/Layout/BlockLayout.swift
@@ -125,9 +125,9 @@ open class BlockLayout: Layout {
     }
   }
 
-  /// Flag determining if user interaction should be enabled for the corresponding view
+  /// Flag determining if user interaction should be enabled for the corresponding view.
   open var userInteractionEnabled: Bool {
-    return !block.disabled
+    return true
   }
 
   /// The position of the block's leading edge X offset, specified as a Workspace coordinate
@@ -141,7 +141,8 @@ open class BlockLayout: Layout {
   /// `performLayout(includeChildren:)`.
   open var firstLineHeight: CGFloat = 0
 
-  /// Flag indicating if this block has had its user interaction disabled.
+  /// Flag indicating if this block is disabled, which means it will be excluded from code
+  /// generation.
   open var disabled: Bool {
     get { return block.disabled }
     set {

--- a/Sources/Layout/Default/DefaultLayoutConfig.swift
+++ b/Sources/Layout/Default/DefaultLayoutConfig.swift
@@ -152,7 +152,7 @@ open class DefaultLayoutConfig: LayoutConfig {
     setColor(ColorPalette.indigo.accent700,
              for: DefaultLayoutConfig.BlockConnectionHighlightStrokeColor)
     setColor(ColorPalette.grey.tint700, for: DefaultLayoutConfig.BlockStrokeDisabledColor)
-    setColor(ColorPalette.grey.tint300, for: DefaultLayoutConfig.BlockFillDisabledColor)
+    setColor(ColorPalette.grey.tint400, for: DefaultLayoutConfig.BlockFillDisabledColor)
     setFloat(0.7, for: DefaultLayoutConfig.BlockDraggingFillColorAlpha)
     setFloat(0.8, for: DefaultLayoutConfig.BlockDraggingStrokeColorAlpha)
     setFloat(1.0, for: DefaultLayoutConfig.BlockDefaultAlpha)

--- a/Sources/Layout/FieldAngleLayout.swift
+++ b/Sources/Layout/FieldAngleLayout.swift
@@ -58,13 +58,6 @@ open class FieldAngleLayout: FieldLayout {
     super.init(field: fieldAngle, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**
@@ -75,9 +68,13 @@ open class FieldAngleLayout: FieldLayout {
    is not a valid integer, `self.fieldAngle` is not updated.
    */
   open func updateAngle(_ angle: Double) {
+    guard fieldAngle.angle != angle else { return }
+
     captureChangeEvent {
-      // Setting to a new angle automatically fires a listener to update the layout
       fieldAngle.angle = angle
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldCheckboxLayout.swift
+++ b/Sources/Layout/FieldCheckboxLayout.swift
@@ -47,13 +47,6 @@ open class FieldCheckboxLayout: FieldLayout {
     super.init(field: fieldCheckbox, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**
@@ -63,9 +56,13 @@ open class FieldCheckboxLayout: FieldLayout {
    - parameter checked: The value used to update `self.fieldCheckbox`.
    */
   open func updateCheckbox(_ checked: Bool) {
+    guard fieldCheckbox.checked != checked else { return }
+
     captureChangeEvent {
-      // Setting to a new checkbox value automatically fires a listener to update the layout
       fieldCheckbox.checked = checked
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldColorLayout.swift
+++ b/Sources/Layout/FieldColorLayout.swift
@@ -45,13 +45,6 @@ open class FieldColorLayout: FieldLayout {
     super.init(field: fieldColor, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**
@@ -61,9 +54,13 @@ open class FieldColorLayout: FieldLayout {
    - parameter color: The value used to update `self.fieldColor`.
    */
   open func updateColor(_ color: UIColor) {
+    guard fieldColor.color != color else { return }
+
     captureChangeEvent {
-      // Setting to a new color automatically fires a listener to update the layout
       fieldColor.color = color
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldDateLayout.swift
+++ b/Sources/Layout/FieldDateLayout.swift
@@ -65,13 +65,6 @@ open class FieldDateLayout: FieldLayout {
     super.init(field: fieldDate, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**
@@ -81,9 +74,13 @@ open class FieldDateLayout: FieldLayout {
    - parameter date: The value used to update `self.fieldDate`.
    */
   open func updateDate(_ date: Date) {
+    guard fieldDate.date != date else { return }
+
     captureChangeEvent {
-      // Setting to a new date automatically fires a listener to update the layout
       fieldDate.date = date
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldDropdownLayout.swift
+++ b/Sources/Layout/FieldDropdownLayout.swift
@@ -57,13 +57,6 @@ open class FieldDropdownLayout: FieldLayout {
     super.init(field: fieldDropdown, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**
@@ -73,9 +66,13 @@ open class FieldDropdownLayout: FieldLayout {
    - parameter selectedIndex: The value used to update `self.fieldDropdown.selectedIndex`.
    */
   open func updateSelectedIndex(_ selectedIndex: Int) {
+    guard fieldDropdown.selectedIndex != selectedIndex else { return }
+
     captureChangeEvent {
-      // Setting to a new index automatically fires a listener to update the layout
       fieldDropdown.selectedIndex = selectedIndex
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldImageLayout.swift
+++ b/Sources/Layout/FieldImageLayout.swift
@@ -45,13 +45,6 @@ open class FieldImageLayout: FieldLayout {
     super.init(field: fieldImage, engine: engine, measurer: measurer)
   }
 
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
-
   // MARK: - Public
 
   /**

--- a/Sources/Layout/FieldInputLayout.swift
+++ b/Sources/Layout/FieldInputLayout.swift
@@ -60,8 +60,7 @@ open class FieldInputLayout: FieldLayout {
     // Update current text value to match the field now
     currentTextValue = fieldInput.text
 
-    // Perform a layout up the tree
-    updateLayoutUpTree()
+    super.didUpdateField(field)
   }
 
   // MARK: - Public
@@ -74,9 +73,11 @@ open class FieldInputLayout: FieldLayout {
    */
   open func updateText(_ text: String) {
     captureChangeEvent {
-      // Setting to new text automatically fires a listener to update the layout
       fieldInput.text = text
       currentTextValue = fieldInput.text
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldLabelLayout.swift
+++ b/Sources/Layout/FieldLabelLayout.swift
@@ -44,11 +44,4 @@ open class FieldLabelLayout: FieldLayout {
     self.fieldLabel = fieldLabel
     super.init(field: fieldLabel, engine: engine, measurer: measurer)
   }
-
-  // MARK: - Super
-
-  open override func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
-  }
 }

--- a/Sources/Layout/FieldLayout.swift
+++ b/Sources/Layout/FieldLayout.swift
@@ -96,6 +96,9 @@ open class FieldLayout: Layout {
     try captureChangeEvent {
       try field.setValueFromSerializedText(text)
     }
+
+    // Perform layout update since the field may need to be resized to reflect its new value.
+    updateLayoutUpTree()
   }
 
   // MARK: - Change Events
@@ -136,7 +139,7 @@ open class FieldLayout: Layout {
 
 extension FieldLayout: FieldListener {
   public func didUpdateField(_ field: Field) {
-    // Perform a layout up the tree
-    updateLayoutUpTree()
+    // Refresh the field since it's been updated
+    sendChangeEvent(withFlags: Layout.Flag_NeedsDisplay)
   }
 }

--- a/Sources/Layout/FieldNumberLayout.swift
+++ b/Sources/Layout/FieldNumberLayout.swift
@@ -75,8 +75,7 @@ open class FieldNumberLayout: FieldLayout {
     // Update current text value to match the field now
     currentTextValue = fieldNumber.textValue
 
-    // Perform a layout up the tree
-    updateLayoutUpTree()
+    super.didUpdateField(field)
   }
 
   // MARK: - Public
@@ -89,9 +88,11 @@ open class FieldNumberLayout: FieldLayout {
     captureChangeEvent {
       fieldNumber.setValueFromLocalizedText(text)
 
-      // Update `currentTextValue` to match the current localized text value of `fieldNumber`,
-      // which will automatically update the corresponding view, if necessary.
+      // Update `currentTextValue` to match the current localized text value of `fieldNumber`.
       currentTextValue = fieldNumber.textValue
     }
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 }

--- a/Sources/Layout/FieldVariableLayout.swift
+++ b/Sources/Layout/FieldVariableLayout.swift
@@ -101,8 +101,7 @@ open class FieldVariableLayout: FieldLayout {
       }
     }
 
-    // Perform a layout up the tree
-    updateLayoutUpTree()
+    super.didUpdateField(field)
   }
 
   // MARK: - Public
@@ -131,6 +130,9 @@ open class FieldVariableLayout: FieldLayout {
           bky_assertionFailure("Could not change to variable: \(error)")
         }
       }
+
+      // Perform a layout up the tree
+      updateLayoutUpTree()
     }
   }
 
@@ -149,6 +151,9 @@ open class FieldVariableLayout: FieldLayout {
       }
     }
     nameManager?.renameName(oldName, to: newName)
+
+    // Perform a layout up the tree
+    updateLayoutUpTree()
   }
 
   /**

--- a/Sources/Model/Block.swift
+++ b/Sources/Model/Block.swift
@@ -129,7 +129,8 @@ public final class Block : NSObject {
   public var movable: Bool {
     didSet { didSetProperty(movable, oldValue) }
   }
-  /// Flag indicating if this block has had its user interaction disabled
+  /// Flag indicating if this block is disabled, which means it will be excluded from code
+  /// generation.
   public var disabled: Bool  {
     didSet { didSetProperty(disabled, oldValue) }
   }

--- a/Sources/Model/Workspace.swift
+++ b/Sources/Model/Workspace.swift
@@ -324,6 +324,7 @@ open class Workspace : NSObject {
 
       for block in blocks {
         block.disabled = deactivated
+        block.editable = !deactivated && !readOnly
         block.movable = !deactivated
       }
     }

--- a/Sources/UI/View Controllers/WorkspaceViewController.swift
+++ b/Sources/UI/View Controllers/WorkspaceViewController.swift
@@ -175,13 +175,18 @@ extension WorkspaceViewController: ViewBuilderDelegate {
     // TODO(#120): This delegate only exists right now so `WorkbenchViewController` can attach
     // gesture recognizers on the BlockView. Refactor this so the gesture recognizers are managed
     // in this view controller.
-    if let blockView = childView as? BlockView {
-      delegate?.workspaceViewController(self, didRemoveBlockView: blockView)
-    }
+    var removedViews = [childView]
+    while let removedView = removedViews.popLast() {
+      removedViews.append(contentsOf: removedView.subviews)
 
-    if let layoutView = childView as? LayoutView, layoutView.popoverDelegate === self {
-      // Unassign this view controller as the layout view's delegate
-      layoutView.popoverDelegate = nil
+      if let blockView = removedView as? BlockView {
+        delegate?.workspaceViewController(self, didRemoveBlockView: blockView)
+      }
+
+      if let layoutView = removedView as? LayoutView, layoutView.popoverDelegate === self {
+        // Unassign this view controller as the layout view's delegate
+        layoutView.popoverDelegate = nil
+      }
     }
   }
 }

--- a/Sources/UI/Views/ViewBuilder.swift
+++ b/Sources/UI/Views/ViewBuilder.swift
@@ -152,12 +152,18 @@ open class ViewBuilder: NSObject {
       let blockGroupView = childView as? BlockGroupView
     {
       workspaceView.removeBlockGroupView(blockGroupView)
-      viewFactory.recycleViewTree(blockGroupView)
       delegate?.viewBuilder(self, didRemoveChild: childView, fromParent: parentView)
+
+      // Recycle the view tree after calling the delegate method. This allows the delegate method
+      // to perform any necessary clean-up prior to deconstructing the view tree.
+      viewFactory.recycleViewTree(blockGroupView)
     } else if childView.superview == parentView {
       childView.removeFromSuperview()
-      viewFactory.recycleViewTree(childView)
       delegate?.viewBuilder(self, didRemoveChild: childView, fromParent: parentView)
+
+      // Recycle the view tree after calling the delegate method. This allows the delegate method
+      // to perform any necessary clean-up prior to deconstructing the view tree.
+      viewFactory.recycleViewTree(childView)
     }
   }
 }


### PR DESCRIPTION
- Fixes FieldLayout from implicitly updating the layout tree on model changes, and made it update explicitly.
- Fixes ViewBuilder bug where it would recycle views prior to calling a delegate method that inspected view hierarchy
- Fixes WorkspaceViewController bug where the didRemoveBlockView() delegate method wasn't being fired

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/447)
<!-- Reviewable:end -->
