### PR TITLE
Fixes bug where popover delegates were being overriden, which caused …

### DIFF
--- a/Sources/UI/View Controllers/WorkbenchViewController.swift
+++ b/Sources/UI/View Controllers/WorkbenchViewController.swift
@@ -1378,8 +1378,8 @@ extension WorkbenchViewController {
 
 extension WorkbenchViewController: WorkspaceViewControllerDelegate {
   open func workspaceViewController(
-    _ workspaceViewController: WorkspaceViewController, didAddBlockView blockView: BlockView)
-  {
+    _ workspaceViewController: WorkspaceViewController,
+    didAddBlockView blockView: BlockView) {
     if workspaceViewController == self.workspaceViewController {
       addGestureTracking(forBlockView: blockView)
       updateWorkspaceCapacity()
@@ -1387,8 +1387,8 @@ extension WorkbenchViewController: WorkspaceViewControllerDelegate {
   }
 
   open func workspaceViewController(
-    _ workspaceViewController: WorkspaceViewController, didRemoveBlockView blockView: BlockView)
-  {
+    _ workspaceViewController: WorkspaceViewController,
+    didRemoveBlockView blockView: BlockView) {
     if workspaceViewController == self.workspaceViewController {
       removeGestureTracking(forBlockView: blockView)
       updateWorkspaceCapacity()
@@ -1396,14 +1396,13 @@ extension WorkbenchViewController: WorkspaceViewControllerDelegate {
   }
 
   open func workspaceViewController(
-    _ workspaceViewController: WorkspaceViewController, willPresentViewController: UIViewController)
-  {
+    _ workspaceViewController: WorkspaceViewController,
+    willPresentViewController viewController: UIViewController) {
     addUIStateValue(.presentingPopover)
   }
 
   open func workspaceViewControllerDismissedViewController(
-    _ workspaceViewController: WorkspaceViewController)
-  {
+    _ workspaceViewController: WorkspaceViewController) {
     removeUIStateValue(.presentingPopover)
   }
 }

--- a/Sources/UI/View Controllers/WorkspaceViewController.swift
+++ b/Sources/UI/View Controllers/WorkspaceViewController.swift
@@ -52,13 +52,14 @@ public protocol WorkspaceViewControllerDelegate {
    Called when the `WorkspaceViewController` is about to present a view controller.
 
    - parameter workspaceViewController: The `WorkspaceViewController` presenting a view controller.
-   - parameter willPresentViewController: The `UIViewController` about to be presented.
+   - parameter viewController: The `UIViewController` about to be presented.
    */
   func workspaceViewController(
-    _ workspaceViewController: WorkspaceViewController, willPresentViewController: UIViewController)
+    _ workspaceViewController: WorkspaceViewController,
+    willPresentViewController viewController: UIViewController)
 
   /**
-   Called when the `WorkspaceViewController` was dismissed.
+   Called when the `WorkspaceViewController` has dismissed a presented view controller.
 
    - parameter workspaceViewController: The `WorkspaceViewController` that dismissed a view
    controller.
@@ -95,6 +96,11 @@ open class WorkspaceViewController: UIViewController {
 
   /// Delegate for events that occur on this view controller
   open weak var delegate: WorkspaceViewControllerDelegate?
+
+  /// Additional presentation delegate that should be notified when a view controller is being
+  /// presented by this instance. This allows both this instance and the source that requested
+  /// the view controller presentation to be notified on presentation events.
+  fileprivate weak var presentationDelegate: UIPopoverPresentationControllerDelegate?
 
   /// The view builder used for managing the view hierarchy
   fileprivate let _viewBuilder: ViewBuilder
@@ -191,12 +197,14 @@ extension WorkspaceViewController: ViewBuilderDelegate {
   }
 }
 
-// MARK: - FieldViewDelegate implementation
+// MARK: - LayoutPopoverDelegate implementation
 
 extension WorkspaceViewController: LayoutPopoverDelegate {
   public func layoutView(
     _ layoutView: LayoutView,
-    requestedToPresentPopoverViewController viewController: UIViewController, fromView: UIView)
+    requestedToPresentPopoverViewController viewController: UIViewController,
+    fromView: UIView,
+    presentationDelegate: UIPopoverPresentationControllerDelegate?)
     -> Bool
   {
     guard !workspaceView.scrollView.isInMotion &&
@@ -218,6 +226,8 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
       self.view.convert(fromView.frame, from: fromView.superview)
     viewController.popoverPresentationController?.delegate = self
 
+    self.presentationDelegate = presentationDelegate
+
     delegate?.workspaceViewController(self, willPresentViewController: viewController)
 
     present(viewController, animated: true, completion: nil)
@@ -228,6 +238,8 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
   public func layoutView(
     _ layoutView: LayoutView, requestedToPresentViewController viewController: UIViewController)
   {
+    self.presentationDelegate = nil
+    
     delegate?.workspaceViewController(self, willPresentViewController: viewController)
 
     present(viewController, animated: true, completion: nil)
@@ -239,31 +251,87 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
     animated: Bool) {
     viewController.dismiss(animated: animated, completion: nil)
 
+    presentationDelegate = nil
+
     // Manually fire our custom delegate since it doesn't automatically get triggered from
     // `self.popoverPresentationControllerDidDismissPopover(:)`.
-    self.delegate?.workspaceViewControllerDismissedViewController(self)
+    delegate?.workspaceViewControllerDismissedViewController(self)
   }
 }
 
-// MARK: - UIPopoverPresentationControllerDelegate implementation
+// MARK: - UIPopoverPresentationControllerDelegate Implementation
 
 extension WorkspaceViewController: UIPopoverPresentationControllerDelegate {
+  @available(iOS 8.3, *)
   public func adaptivePresentationStyle(for controller: UIPresentationController,
     traitCollection: UITraitCollection) -> UIModalPresentationStyle
   {
     // Force this view controller to always show up in a popover
-    return UIModalPresentationStyle.none
+    return
+      presentationDelegate?.adaptivePresentationStyle?(
+        for:controller, traitCollection:traitCollection)
+      ?? UIModalPresentationStyle.none
+  }
+
+  public func adaptivePresentationStyle(for controller: UIPresentationController)
+    -> UIModalPresentationStyle {
+    return presentationDelegate?.adaptivePresentationStyle?(for: controller)
+      ?? UIModalPresentationStyle.none
+  }
+
+  public func presentationController(
+    _ controller: UIPresentationController,
+    viewControllerForAdaptivePresentationStyle style: UIModalPresentationStyle)
+    -> UIViewController? {
+      return presentationDelegate?
+        .presentationController?(controller, viewControllerForAdaptivePresentationStyle: style)
+  }
+
+  @available(iOS 8.3, *)
+  public func presentationController(
+    _ presentationController: UIPresentationController,
+    willPresentWithAdaptiveStyle style: UIModalPresentationStyle,
+    transitionCoordinator: UIViewControllerTransitionCoordinator?) {
+    presentationDelegate?.presentationController?(presentationController,
+                                                  willPresentWithAdaptiveStyle: style,
+                                                  transitionCoordinator: transitionCoordinator)
+  }
+
+  public func prepareForPopoverPresentation(_ popoverPresentationController:
+    UIPopoverPresentationController) {
+    presentationDelegate?.prepareForPopoverPresentation?(popoverPresentationController)
+  }
+
+  public func popoverPresentationControllerShouldDismissPopover(
+    _ popoverPresentationController: UIPopoverPresentationController) -> Bool {
+    return
+      presentationDelegate?
+        .popoverPresentationControllerShouldDismissPopover?(popoverPresentationController)
+      ?? true
   }
 
   public func popoverPresentationControllerDidDismissPopover(
     _ popoverPresentationController: UIPopoverPresentationController)
   {
+    presentationDelegate?
+      .popoverPresentationControllerDidDismissPopover?(popoverPresentationController)
+
+    presentationDelegate = nil
     delegate?.workspaceViewControllerDismissedViewController(self)
+  }
+
+  public func popoverPresentationController(
+    _ popoverPresentationController: UIPopoverPresentationController,
+    willRepositionPopoverTo rect: UnsafeMutablePointer<CGRect>,
+    in view: AutoreleasingUnsafeMutablePointer<UIView>) {
+    presentationDelegate?.popoverPresentationController?(
+      popoverPresentationController, willRepositionPopoverTo: rect, in: view)
   }
 
   open override func dismiss(animated flag: Bool, completion: (() -> Void)?) {
     super.dismiss(animated: flag, completion: completion)
 
+    presentationDelegate = nil
     delegate?.workspaceViewControllerDismissedViewController(self)
   }
 }

--- a/Sources/UI/View Controllers/WorkspaceViewController.swift
+++ b/Sources/UI/View Controllers/WorkspaceViewController.swift
@@ -239,7 +239,7 @@ extension WorkspaceViewController: LayoutPopoverDelegate {
     _ layoutView: LayoutView, requestedToPresentViewController viewController: UIViewController)
   {
     self.presentationDelegate = nil
-    
+
     delegate?.workspaceViewController(self, willPresentViewController: viewController)
 
     present(viewController, animated: true, completion: nil)

--- a/Sources/UI/Views/FieldAngleView.swift
+++ b/Sources/UI/Views/FieldAngleView.swift
@@ -117,11 +117,10 @@ extension FieldAngleView: UITextFieldDelegate {
     // Start a new event group for this edit.
     _eventGroupID = UUID().uuidString
 
-    popoverDelegate?
-      .layoutView(self, requestedToPresentPopoverViewController: viewController, fromView: self)
-
-    // Set the delegate so we can prioritize arrow directions
-    viewController.popoverPresentationController?.delegate = self
+    popoverDelegate?.layoutView(self,
+                                requestedToPresentPopoverViewController: viewController,
+                                fromView: self,
+                                presentationDelegate: self)
 
     // Hide keyboard
     endEditing(true)

--- a/Sources/UI/Views/FieldColorView.swift
+++ b/Sources/UI/Views/FieldColorView.swift
@@ -92,8 +92,10 @@ open class FieldColorView: FieldView {
     let viewController = FieldColorPickerViewController()
     viewController.color = fieldColorLayout?.color
     viewController.delegate = self
-    popoverDelegate?
-      .layoutView(self, requestedToPresentPopoverViewController: viewController, fromView: self)
+    popoverDelegate?.layoutView(self,
+                                requestedToPresentPopoverViewController: viewController,
+                                fromView: self,
+                                presentationDelegate: nil)
   }
 }
 

--- a/Sources/UI/Views/FieldDropdownView.swift
+++ b/Sources/UI/Views/FieldDropdownView.swift
@@ -148,11 +148,10 @@ extension FieldDropdownView: DropdownViewDelegate {
       viewController.textLabelFont = fontCreator(max(fieldDropdownLayout.engine.scale, 1.0))
     }
 
-    popoverDelegate?
-      .layoutView(self, requestedToPresentPopoverViewController: viewController, fromView: self)
-
-    // Set the delegate so we can prioritize arrow directions
-    viewController.popoverPresentationController?.delegate = self
+    popoverDelegate?.layoutView(self,
+                                requestedToPresentPopoverViewController: viewController,
+                                fromView: self,
+                                presentationDelegate: self)
   }
 }
 

--- a/Sources/UI/Views/FieldNumberView.swift
+++ b/Sources/UI/Views/FieldNumberView.swift
@@ -161,11 +161,10 @@ extension FieldNumberView: UITextFieldDelegate {
     // Start a new event group for this edit.
     _eventGroupID = UUID().uuidString
 
-    popoverDelegate?
-      .layoutView(self, requestedToPresentPopoverViewController: viewController, fromView: self)
-
-    // Set the delegate so we can prioritize arrow directions
-    viewController.popoverPresentationController?.delegate = self
+    popoverDelegate?.layoutView(self,
+                                requestedToPresentPopoverViewController: viewController,
+                                fromView: self,
+                                presentationDelegate: self)
 
     self.numberPadViewController = viewController
 

--- a/Sources/UI/Views/LayoutView.swift
+++ b/Sources/UI/Views/LayoutView.swift
@@ -36,12 +36,15 @@ public protocol LayoutPopoverDelegate {
    - parameter layoutView: The `LayoutView` that made the request
    - parameter viewController: The `UIViewController` to present
    - parameter fromView: The `UIView` where the popover should pop up from
+   - parameter presentationDelegate: A `UIPopoverPresentationControllerDelegate` that should
+   be notified when presentation events are fired.
    - returns: `true` if the `viewController` was presented. `false` otherwise.
    */
   @discardableResult
   func layoutView(_ layoutView: LayoutView,
                  requestedToPresentPopoverViewController viewController: UIViewController,
-                 fromView: UIView) -> Bool
+                 fromView: UIView,
+                 presentationDelegate: UIPopoverPresentationControllerDelegate?) -> Bool
 
   /**
    Event is called when a layout view requests to dismiss a view controller.

--- a/Sources/UI/Views/MutatorIfElseView.swift
+++ b/Sources/UI/Views/MutatorIfElseView.swift
@@ -111,10 +111,8 @@ open class MutatorIfElseView: LayoutView {
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,
-                                fromView: popoverButton)
-
-    // Set the delegate so we can prioritize arrow directions
-    viewController.popoverPresentationController?.delegate = self
+                                fromView: popoverButton,
+                                presentationDelegate: self)
   }
 }
 

--- a/Sources/UI/Views/MutatorProcedureDefinitionView.swift
+++ b/Sources/UI/Views/MutatorProcedureDefinitionView.swift
@@ -110,10 +110,8 @@ open class MutatorProcedureDefinitionView: LayoutView {
 
     popoverDelegate?.layoutView(self,
                                 requestedToPresentPopoverViewController: viewController,
-                                fromView: popoverButton)
-
-    // Set the delegate so we can prioritize arrow directions
-    viewController.popoverPresentationController?.delegate = self
+                                fromView: popoverButton,
+                                presentationDelegate: self)
   }
 }
 


### PR DESCRIPTION
…undo/redo buttons to stay disabled after popover dismissal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/450)
<!-- Reviewable:end -->
