### PR TITLE
Hides trash view immediately after a block is dragged out of it

### DIFF
--- a/Sources/UI/View Controllers/WorkbenchViewController.swift
+++ b/Sources/UI/View Controllers/WorkbenchViewController.swift
@@ -1702,6 +1702,8 @@ extension WorkbenchViewController: BlocklyPanGestureRecognizerDelegate {
         gesture.replaceBlock(block, with: newBlock)
         blockView = newBlock
         removeBlockFromTrash(oldBlock)
+
+        removeUIStateValue(.trashCanOpen, animated: false)
       }
 
       guard let blockLayout = blockView.blockLayout?.draggableBlockLayout else {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/478)
<!-- Reviewable:end -->
