### PR TITLE
- Changes workbench's default behavior to set the viewport to the top…

### DIFF
--- a/Sources/UI/View Controllers/ToolboxCategoryViewController.swift
+++ b/Sources/UI/View Controllers/ToolboxCategoryViewController.swift
@@ -119,6 +119,7 @@ import Foundation
       workspaceScrollView.contentInsetAdjustmentBehavior = .always
     }
 
+    workspaceViewController.workspaceView.scrollIntoViewEdgeInsets = .zero
     workspaceViewController.workspaceView.allowCanvasPadding = false
     workspaceViewController.workspaceView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Sources/UI/View Controllers/WorkbenchViewController.swift
+++ b/Sources/UI/View Controllers/WorkbenchViewController.swift
@@ -737,11 +737,8 @@ public protocol WorkbenchViewControllerDelegate: class {
 
     refreshView()
 
-    // Automatically change the viewport to show the top-most block
-    if let topBlock =
-      workspace.topLevelBlocks().sorted(by: { $0.position.y <= $1.position.y }).first {
-      scrollBlockIntoView(blockUUID: topBlock.uuid, location: .topLeading, animated: false)
-    }
+    // Automatically change the viewport to show the top-leading part of the workspace.
+    setViewport(to: .topLeading, animated: false)
 
     // Fire any events that were created as a result of loading a new workspace.
     EventManager.shared.firePendingEvents()
@@ -1706,6 +1703,23 @@ extension WorkbenchViewController {
     // to scroll blocks into the view, immediately after the workspace has loaded, does not work.
     DispatchQueue.main.async {
       self.workspaceView.scrollBlockIntoView(block, location: location, animated: animated)
+    }
+  }
+
+  /**
+   Sets the content offset of the workspace's scroll view so that a specific location in the
+   workspace is visible.
+
+   - parameter location: The `Location` that should be made visible. If `.anywhere` is specified,
+   this method does nothing.
+   - parameter animated: Flag determining if this scroll view adjustment should be animated.
+   */
+  public func setViewport(to location: WorkspaceView.Location, animated: Bool) {
+    // Always perform this method at the end of the run loop, in order to ensure views have first
+    // been created/positioned in the scroll view. This fixes a problem where attempting
+    // to scroll blocks into the view, immediately after the workspace has loaded, does not work.
+    DispatchQueue.main.async {
+      self.workspaceView.setViewport(to: location, animated: animated)
     }
   }
 }

--- a/Sources/UI/Views/WorkspaceView.swift
+++ b/Sources/UI/Views/WorkspaceView.swift
@@ -95,9 +95,12 @@ View for rendering a `WorkspaceLayout`.
   open var canvasPaddingScale = EdgeInsets(top: 0.5, leading: 0.2, bottom: 0.95, trailing: 0.9)
 
   /**
-  The amount of padding that should be added to the edges when automatically scrolling a
-  `Block` into view.
-  */
+   The amount of padding that should be added to the edges when automatically scrolling a
+   `Block` into view or setting the viewport to a specific location.
+
+   - note: See `scrollBlockIntoView(_:location:animated:)` and `setViewport(to:animated:)` for
+   more information.
+   */
   open var scrollIntoViewEdgeInsets = EdgeInsets(top: 20, leading: 20, bottom: 100, trailing: 20)
 
   /// Enables/disables the zooming of a workspace. Defaults to false.
@@ -375,6 +378,8 @@ View for rendering a `WorkspaceLayout`.
 
    - parameter location: The `Location` that should be made visible. If `.anywhere` is specified,
    this method does nothing.
+   - parameter animated: Flag determining if this scroll view adjustment should be animated.
+   - note: See `scrollIntoViewEdgeInsets`.
    */
   open func setViewport(to location: Location, animated: Bool) {
     guard let workspaceLayout = self.workspaceLayout, location != .anywhere else {
@@ -382,7 +387,10 @@ View for rendering a `WorkspaceLayout`.
     }
 
     var contentOffset = CGPoint.zero
-    var scrollAreaInsets = UIEdgeInsets.zero
+    var scrollAreaInsets = UIEdgeInsets(top: scrollIntoViewEdgeInsets.top,
+                                        left: scrollIntoViewEdgeInsets.left,
+                                        bottom: scrollIntoViewEdgeInsets.bottom,
+                                        right: scrollIntoViewEdgeInsets.right)
 
     // Make sure the insets accounts for the safe area
     if #available(iOS 11.0, *) {


### PR DESCRIPTION
…-leading workspace location

- Updates WorkspaceView.setViewport(...) to use scrollIntoViewEdgeInsets property

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/491)
<!-- Reviewable:end -->
