### PR TITLE
Fixes turtle demo so it stops highlighting/scrolling blocks into view…

### DIFF
--- a/Samples/BlocklySample/BlocklySample/Sources/TurtleObjCViewController.m
+++ b/Samples/BlocklySample/BlocklySample/Sources/TurtleObjCViewController.m
@@ -448,18 +448,23 @@ NSString *const TurtleObjCViewController_JSCallbackName = @"TurtleViewController
 - (void)workbenchViewController:(BKYWorkbenchViewController *)workbenchViewController
                didUpdateState:(NSSet *)state {
 
-  // Only allow automatic scrolling if the user tapped the workspace.
-  _allowScrollingToBlockView =
-    [state isSubsetOfSet:[NSSet setWithObject:@(workbenchViewController.stateDidTapWorkspace)]];
+  if (_allowScrollingToBlockView) {
+    // Only continue to allow automatic scrolling if the user tapped the workspace.
+    _allowScrollingToBlockView =
+      [state isSubsetOfSet:[NSSet setWithObject:@(workbenchViewController.stateDidTapWorkspace)]];
+  }
 
-  // Only allow block highlighting if the user tapped/panned or opened the toolbox or trash can.
-  _allowBlockHighlighting = [state isSubsetOfSet: [NSSet setWithObjects:
-    @(workbenchViewController.stateDidTapWorkspace),
-    @(workbenchViewController.stateDidPanWorkspace),
-    @(workbenchViewController.stateCategoryOpen),
-    @(workbenchViewController.stateTrashCanOpen),
-    nil
-  ]];
+  if (_allowBlockHighlighting) {
+    // Only continue to allow block highlighting if the user tapped/panned or opened the toolbox or
+    // trash can.
+    _allowBlockHighlighting = [state isSubsetOfSet: [NSSet setWithObjects:
+      @(workbenchViewController.stateDidTapWorkspace),
+      @(workbenchViewController.stateDidPanWorkspace),
+      @(workbenchViewController.stateCategoryOpen),
+      @(workbenchViewController.stateTrashCanOpen),
+      nil
+    ]];
+  }
 }
 
 @end

--- a/Samples/BlocklySample/BlocklySample/Sources/TurtleSwiftViewController.swift
+++ b/Samples/BlocklySample/BlocklySample/Sources/TurtleSwiftViewController.swift
@@ -412,16 +412,21 @@ extension TurtleSwiftViewController: WorkbenchViewControllerDelegate {
     // We need to disable automatic block view scrolling / block highlighting based on the latest
     // user interaction.
 
-    // Only allow automatic scrolling if the user tapped on the workspace.
-    _allowScrollingToBlockView = state.isSubset(of: [workbenchViewController.stateDidTapWorkspace])
+    if _allowScrollingToBlockView {
+      // Only continue to allow automatic scrolling if the user tapped on the workspace.
+      _allowScrollingToBlockView =
+        state.isSubset(of: [workbenchViewController.stateDidTapWorkspace])
+    }
 
-    // Only allow block highlighting if the user tapped/panned the workspace or opened either the
-    // toolbox or trash can.
-    _allowBlockHighlighting = state.isSubset(of: [
-      workbenchViewController.stateDidTapWorkspace,
-      workbenchViewController.stateDidPanWorkspace,
-      workbenchViewController.stateCategoryOpen,
-      workbenchViewController.stateTrashCanOpen])
+    if _allowBlockHighlighting {
+      // Only continue to allow block highlighting if the user tapped/panned the workspace or
+      // opened either the toolbox or trash can.
+      _allowBlockHighlighting = state.isSubset(of: [
+        workbenchViewController.stateDidTapWorkspace,
+        workbenchViewController.stateDidPanWorkspace,
+        workbenchViewController.stateCategoryOpen,
+        workbenchViewController.stateTrashCanOpen])
+    }
   }
 }
 


### PR DESCRIPTION
… if the user has edited the workspace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/blockly-ios/493)
<!-- Reviewable:end -->
